### PR TITLE
Add asyncio trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development',
+        'Framework :: AsyncIO',
     ],
     url="https://github.com/aio-libs/aiodocker",
     platforms=['any'],


### PR DESCRIPTION
The `Framework :: AsyncIO` [trove classifier](https://pypi.python.org/pypi?%3Aaction=list_classifiers) has recently been added to PyPI. It can help people discover asyncio related packages.