### PR TITLE
add tests support for python 3.5.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   aiodocker:
-    image: python:3.6.1-alpine
+    image: python:${TRAVIS_PYTHON_VERSION}-alpine
     depends_on:
       - docker
       - registry

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,2 +1,3 @@
+setuptools==36.2.0
 aiohttp==2.2.3
 yarl>=0.10


### PR DESCRIPTION
With this PR all tests will used the correct Python version (3.5, 3.5.2 and 3.6)