### PR TITLE
Add events task

### DIFF
--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -503,16 +503,15 @@ class DockerEvents:
                 self._transform_event,
                 human_bool(params['stream']),
             )
-            async for data in self.json_stream:
-                await self.channel.publish(data)
+            try:
+                async for data in self.json_stream:
+                    await self.channel.publish(data)
+            finally:
+                await self.json_stream._close()
+                self.json_stream = None
         finally:
             # signal termination to subscribers
             await self.channel.publish(None)
-            try:
-                await self.json_stream._close()
-            except:
-                pass
-            self.json_stream = None
 
     async def stop(self):
         if self.json_stream is not None:

--- a/aiodocker/jsonstream.py
+++ b/aiodocker/jsonstream.py
@@ -39,7 +39,7 @@ class _JsonStreamResult:
         # (see https://github.com/KeepSafe/aiohttp/issues/739)
 
         # response error , it has been closed
-        await self._response.close()
+        self._response.close()
 
 
 async def json_stream_result(response, transform=None, stream=True):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,24 @@
+import asyncio
+
+import pytest
+
+
+def test_events_default_task(docker):
+    loop = asyncio.get_event_loop()
+    docker.events.subscribe()
+    assert docker.events.task is not None
+    loop.run_until_complete(docker.events.stop())
+    assert docker.events.task.done()
+    assert docker.events.json_stream is None
+
+
+def test_events_provided_task(docker):
+    loop = asyncio.get_event_loop()
+    task = asyncio.ensure_future(docker.events.run())
+    docker.events.subscribe(create_task=False)
+    assert docker.events.task is None
+    loop.run_until_complete(docker.events.stop())
+    assert docker.events.json_stream is None
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        loop.run_until_complete(task)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -230,3 +230,5 @@ async def test_events(docker, testing_images, event_loop):
             break
 
     assert events_occurred == ['create', 'start', 'kill', 'die', 'destroy']
+
+    await docker.events.stop()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -203,7 +203,6 @@ async def test_port(docker, testing_images, redis_container):
 
 @pytest.mark.asyncio
 async def test_events(docker, testing_images, event_loop):
-    monitor_task = event_loop.create_task(docker.events.run())
     subscriber = docker.events.subscribe()
 
     # Do some stuffs to generate events.
@@ -231,4 +230,3 @@ async def test_events(docker, testing_images, event_loop):
             break
 
     assert events_occurred == ['create', 'start', 'kill', 'die', 'destroy']
-    monitor_task.cancel()


### PR DESCRIPTION
## What These Changes Do

1. ~Explicit loop~
2. Fix a problem with ClientResponse is not a coroutine
3. DockerEvents automatically create and cancel a background task by default (breaking change)

