### PR TITLE
Add missing includes in the MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
 include LICENSE
 include README.rst
+include CHANGES.rst
+include requirements/base.txt
+include requirements/test.txt
 graft aiodocker
 graft examples
 graft tests


### PR DESCRIPTION
The installation from PyPi will fail if the user miss those files.

To test:

```
python setup.py sdist
easy_install --user -U -Z aiodocker-0.8.0a0.tar.gz
```

It must succeeds.