### PR TITLE
Split sub-API classes into separate modules (#28)

### DIFF
--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -1,0 +1,251 @@
+import json
+
+from .exceptions import DockerError
+from .jsonstream import json_stream_result
+from .multiplexed import multiplexed_result
+from .utils import identical, parse_result
+
+from .logs import DockerLog
+
+
+class DockerContainers(object):
+    def __init__(self, docker):
+        self.docker = docker
+
+    async def list(self, **kwargs):
+        data = await self.docker._query_json(
+            "containers/json",
+            method='GET',
+            params=kwargs
+        )
+        return [DockerContainer(self.docker, **x) for x in data]
+
+    async def create_or_replace(self, name, config):
+        container = None
+
+        try:
+            container = await self.get(name)
+            if not identical(config, container._container):
+                running = container._container.get(
+                    "State", {}).get("Running", False)
+                if running:
+                    await container.stop()
+                await container.delete()
+                container = None
+        except DockerError:
+            pass
+
+        if container is None:
+            container = await self.create(config, name=name)
+
+        return container
+
+    async def create(self, config, name=None):
+        url = "containers/create"
+
+        config = json.dumps(config, sort_keys=True).encode('utf-8')
+        kwargs = {}
+        if name:
+            kwargs['name'] = name
+        data = await self.docker._query_json(
+            url,
+            method='POST',
+            headers={"content-type": "application/json"},
+            data=config,
+            params=kwargs
+        )
+        return DockerContainer(self.docker, id=data['Id'])
+
+    async def run(self, config, name=None):
+
+        try:
+            container = await self.create(config, name)
+        except DockerError as e:
+
+            # image not find, try pull it
+
+            if e.status == 404:
+
+                if 'Image' in config:
+                    try:
+                        await self.docker.pull(config['Image'])
+                    except DockerError as e:
+                        raise e
+
+                    container = await self.create(config, name)
+            else:
+                raise e
+        await container.start()
+        return container
+
+    async def get(self, container, **kwargs):
+        data = await self.docker._query_json(
+            "containers/{container}/json".format(container=container),
+            method='GET',
+            params=kwargs
+        )
+        return DockerContainer(self.docker, **data)
+
+    def container(self, container_id, **kwargs):
+        data = {
+            'id': container_id
+        }
+        data.update(kwargs)
+        return DockerContainer(self.docker, **data)
+
+
+class DockerContainer:
+    def __init__(self, docker, **kwargs):
+        self.docker = docker
+        self._container = kwargs
+        self._id = self._container.get("id", self._container.get(
+            "ID", self._container.get("Id")))
+        self.logs = DockerLog(docker, self)
+
+    async def log(self, stdout=False, stderr=False, follow=False, **kwargs):
+        if stdout is False and stderr is False:
+            raise TypeError("Need one of stdout or stderr")
+
+        params = {
+            "stdout": stdout,
+            "stderr": stderr,
+            "follow": follow,
+        }
+        params.update(kwargs)
+
+        inspect_info = await self.show()
+        is_tty = inspect_info['Config']['Tty']
+
+        response = await self.docker._query(
+            "containers/{self._id}/logs".format(self=self),
+            method='GET',
+            params=params,
+        )
+        return (await multiplexed_result(response, follow, is_tty=is_tty))
+
+    async def copy(self, resource, **kwargs):
+        # TODO: this is deprecated, use get_archive instead
+        request = json.dumps({
+            "Resource": resource,
+        }, sort_keys=True).encode('utf-8')
+        data = await self.docker._query(
+            "containers/{self._id}/copy".format(self=self),
+            method='POST',
+            data=request,
+            headers={"content-type": "application/json"},
+            params=kwargs
+        )
+        return data
+
+    async def put_archive(self, path, data):
+        response = await self.docker._query(
+            "containers/{self._id}/archive".format(self=self),
+            method='PUT',
+            data=data,
+            headers={"content-type": "application/json"},
+            params={'path': path}
+        )
+        data = await parse_result(response)
+        return data
+
+    async def show(self, **kwargs):
+        data = await self.docker._query_json(
+            "containers/{self._id}/json".format(self=self),
+            method='GET',
+            params=kwargs
+        )
+        self._container = data
+        return data
+
+    async def stop(self, **kwargs):
+        response = await self.docker._query(
+            "containers/{self._id}/stop".format(self=self),
+            method='POST',
+            params=kwargs
+        )
+        await response.release()
+        return
+
+    async def start(self, **kwargs):
+        response = await self.docker._query(
+            "containers/{self._id}/start".format(self=self),
+            method='POST',
+            headers={"content-type": "application/json"},
+            data=kwargs
+        )
+        await response.release()
+        return
+
+    async def kill(self, **kwargs):
+        response = await self.docker._query(
+            "containers/{self._id}/kill".format(self=self),
+            method='POST',
+            params=kwargs
+        )
+        await response.release()
+        return
+
+    async def wait(self, timeout=None, **kwargs):
+        data = await self.docker._query_json(
+            "containers/{self._id}/wait".format(self=self),
+            method='POST',
+            params=kwargs,
+            timeout=timeout,
+        )
+        return data
+
+    async def delete(self, **kwargs):
+        response = await self.docker._query(
+            "containers/{self._id}".format(self=self),
+            method='DELETE',
+            params=kwargs
+        )
+        await response.release()
+        return
+
+    async def websocket(self, **params):
+        path = "containers/{self._id}/attach/ws".format(self=self)
+        ws = await self.docker._websocket(path, **params)
+        return ws
+
+    async def port(self, private_port):
+        if 'NetworkSettings' not in self._container:
+            await self.show()
+
+        private_port = str(private_port)
+        h_ports = None
+
+        # Port settings is None when the container is running with
+        # network_mode=host.
+        port_settings = self._container.get('NetworkSettings', {}).get('Ports')
+        if port_settings is None:
+            return None
+
+        if '/' in private_port:
+            return port_settings.get(private_port)
+
+        h_ports = port_settings.get(private_port + '/tcp')
+        if h_ports is None:
+            h_ports = port_settings.get(private_port + '/udp')
+
+        return h_ports
+
+    async def stats(self, stream=True):
+        if stream:
+            response = await self.docker._query(
+                "containers/{self._id}/stats".format(self=self),
+                params={'stream': '1'},
+            )
+            return (await json_stream_result(response))
+        else:
+            data = await self.docker._query_json(
+                "containers/{self._id}/stats".format(self=self),
+                params={'stream': '0'},
+            )
+            return data
+
+    def __getitem__(self, key):
+        return self._container[key]
+
+    def __hasitem__(self, key):
+        return key in self._container

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -1,6 +1,4 @@
 import asyncio
-from collections import ChainMap
-import datetime as dt
 import io
 import json
 import logging
@@ -15,15 +13,31 @@ import aiohttp
 from yarl import URL
 
 from .channel import Channel
-from .exceptions import DockerError
-from .utils import identical, human_bool, httpize
-from .multiplexed import multiplexed_result
 from .jsonstream import json_stream_result
+from .utils import identical, human_bool, httpize, parse_result
+
+# Sub-API classes
+from .containers import DockerContainers, DockerContainer
+from .events import DockerEvents
+from .exceptions import DockerError
+from .images import DockerImages
+from .logs import DockerLog
 from .swarm import DockerSwarm
 from .services import DockerServices
 from .tasks import DockerTasks
+from .volumes import DockerVolumes, DockerVolume
 
-from .images import DockerImages
+__all__ = (
+    'Docker',
+    'DockerContainers', 'DockerContainer',
+    'DockerEvents',
+    'DockerError',
+    'DockerImages',
+    'DockerSwarm',
+    'DockerServices',
+    'DockerTasks',
+    'DockerVolumes', 'DockerVolume',
+)
 
 log = logging.getLogger(__name__)
 
@@ -146,38 +160,6 @@ class Docker:
 
         return response
 
-    @staticmethod
-    async def _result(response, response_type=None):
-        '''
-        Convert the response to native objects by the given response type
-        or the auto-detected HTTP content-type.
-        It also ensures release of the response object.
-        '''
-        try:
-            if not response_type:
-                ct = response.headers.get("Content-Type", "")
-                if 'json' in ct:
-                    response_type = 'json'
-                elif 'x-tar' in ct:
-                    response_type = 'tar'
-                elif 'text/plain' in ct:
-                    response_type = 'text'
-                else:
-                    raise TypeError("Unrecognized response type: {ct}"
-                                    .format(ct=ct))
-            if 'tar' == response_type:
-                what = await response.read()
-                return tarfile.open(mode='r', fileobj=io.BytesIO(what))
-            if 'json' == response_type:
-                data = await response.json(encoding='utf-8')
-            elif 'text' == response_type:
-                data = await response.text(encoding='utf-8')
-            else:
-                data = await response.read()
-            return data
-        finally:
-            await response.release()
-
     async def _websocket(self, path, **params):
         if not params:
             params = {
@@ -199,7 +181,7 @@ class Docker:
         A shorthand of _query() followed by _result() with JSON response type.
         '''
         response = await self._query(*args, **kwargs)
-        data = await Docker._result(response, 'json')
+        data = await parse_result(response, 'json')
         return data
 
     @staticmethod
@@ -218,403 +200,3 @@ class Docker:
         context.load_cert_chain(certfile=certs_path / 'cert.pem',
                                 keyfile=certs_path / 'key.pem')
         return context
-
-
-class DockerContainers(object):
-    def __init__(self, docker):
-        self.docker = docker
-
-    async def list(self, **kwargs):
-        data = await self.docker._query_json(
-            "containers/json",
-            method='GET',
-            params=kwargs
-        )
-        return [DockerContainer(self.docker, **x) for x in data]
-
-    async def create_or_replace(self, name, config):
-        container = None
-
-        try:
-            container = await self.get(name)
-            if not identical(config, container._container):
-                running = container._container.get(
-                    "State", {}).get("Running", False)
-                if running:
-                    await container.stop()
-                await container.delete()
-                container = None
-        except DockerError:
-            pass
-
-        if container is None:
-            container = await self.create(config, name=name)
-
-        return container
-
-    async def create(self, config, name=None):
-        url = "containers/create"
-
-        config = json.dumps(config, sort_keys=True).encode('utf-8')
-        kwargs = {}
-        if name:
-            kwargs['name'] = name
-        data = await self.docker._query_json(
-            url,
-            method='POST',
-            headers={"content-type": "application/json"},
-            data=config,
-            params=kwargs
-        )
-        return DockerContainer(self.docker, id=data['Id'])
-
-    async def run(self, config, name=None):
-
-        try:
-            container = await self.create(config, name)
-        except DockerError as e:
-
-            # image not find, try pull it
-
-            if e.status == 404:
-
-                if 'Image' in config:
-                    try:
-                        await self.docker.pull(config['Image'])
-                    except DockerError as e:
-                        raise e
-
-                    container = await self.create(config, name)
-            else:
-                raise e
-        await container.start()
-        return container
-
-    async def get(self, container, **kwargs):
-        data = await self.docker._query_json(
-            "containers/{container}/json".format(container=container),
-            method='GET',
-            params=kwargs
-        )
-        return DockerContainer(self.docker, **data)
-
-    def container(self, container_id, **kwargs):
-        data = {
-            'id': container_id
-        }
-        data.update(kwargs)
-        return DockerContainer(self.docker, **data)
-
-
-class DockerContainer:
-    def __init__(self, docker, **kwargs):
-        self.docker = docker
-        self._container = kwargs
-        self._id = self._container.get("id", self._container.get(
-            "ID", self._container.get("Id")))
-        self.logs = DockerLog(docker, self)
-
-    async def log(self, stdout=False, stderr=False, follow=False, **kwargs):
-        if stdout is False and stderr is False:
-            raise TypeError("Need one of stdout or stderr")
-
-        params = {
-            "stdout": stdout,
-            "stderr": stderr,
-            "follow": follow,
-        }
-        params.update(kwargs)
-
-        inspect_info = await self.show()
-        is_tty = inspect_info['Config']['Tty']
-
-        response = await self.docker._query(
-            "containers/{self._id}/logs".format(self=self),
-            method='GET',
-            params=params,
-        )
-        return (await multiplexed_result(response, follow, is_tty=is_tty))
-
-    async def copy(self, resource, **kwargs):
-        # TODO: this is deprecated, use get_archive instead
-        request = json.dumps({
-            "Resource": resource,
-        }, sort_keys=True).encode('utf-8')
-        data = await self.docker._query(
-            "containers/{self._id}/copy".format(self=self),
-            method='POST',
-            data=request,
-            headers={"content-type": "application/json"},
-            params=kwargs
-        )
-        return data
-
-    async def put_archive(self, path, data):
-        response = await self.docker._query(
-            "containers/{self._id}/archive".format(self=self),
-            method='PUT',
-            data=data,
-            headers={"content-type": "application/json"},
-            params={'path': path}
-        )
-        data = await Docker._result(response)
-        return data
-
-    async def show(self, **kwargs):
-        data = await self.docker._query_json(
-            "containers/{self._id}/json".format(self=self),
-            method='GET',
-            params=kwargs
-        )
-        self._container = data
-        return data
-
-    async def stop(self, **kwargs):
-        response = await self.docker._query(
-            "containers/{self._id}/stop".format(self=self),
-            method='POST',
-            params=kwargs
-        )
-        await response.release()
-        return
-
-    async def start(self, **kwargs):
-        response = await self.docker._query(
-            "containers/{self._id}/start".format(self=self),
-            method='POST',
-            headers={"content-type": "application/json"},
-            data=kwargs
-        )
-        await response.release()
-        return
-
-    async def kill(self, **kwargs):
-        response = await self.docker._query(
-            "containers/{self._id}/kill".format(self=self),
-            method='POST',
-            params=kwargs
-        )
-        await response.release()
-        return
-
-    async def wait(self, timeout=None, **kwargs):
-        data = await self.docker._query_json(
-            "containers/{self._id}/wait".format(self=self),
-            method='POST',
-            params=kwargs,
-            timeout=timeout,
-        )
-        return data
-
-    async def delete(self, **kwargs):
-        response = await self.docker._query(
-            "containers/{self._id}".format(self=self),
-            method='DELETE',
-            params=kwargs
-        )
-        await response.release()
-        return
-
-    async def websocket(self, **params):
-        path = "containers/{self._id}/attach/ws".format(self=self)
-        ws = await self.docker._websocket(path, **params)
-        return ws
-
-    async def port(self, private_port):
-        if 'NetworkSettings' not in self._container:
-            await self.show()
-
-        private_port = str(private_port)
-        h_ports = None
-
-        # Port settings is None when the container is running with
-        # network_mode=host.
-        port_settings = self._container.get('NetworkSettings', {}).get('Ports')
-        if port_settings is None:
-            return None
-
-        if '/' in private_port:
-            return port_settings.get(private_port)
-
-        h_ports = port_settings.get(private_port + '/tcp')
-        if h_ports is None:
-            h_ports = port_settings.get(private_port + '/udp')
-
-        return h_ports
-
-    async def stats(self, stream=True):
-        if stream:
-            response = await self.docker._query(
-                "containers/{self._id}/stats".format(self=self),
-                params={'stream': '1'},
-            )
-            return (await json_stream_result(response))
-        else:
-            data = await self.docker._query_json(
-                "containers/{self._id}/stats".format(self=self),
-                params={'stream': '0'},
-            )
-            return data
-
-    def __getitem__(self, key):
-        return self._container[key]
-
-    def __hasitem__(self, key):
-        return key in self._container
-
-
-class DockerEvents:
-    def __init__(self, docker):
-        self.docker = docker
-        self.channel = Channel()
-        self.json_stream = None
-        self.task = None
-
-    def listen(self):
-        warnings.warn("use subscribe() method instead",
-                      DeprecationWarning, stacklevel=2)
-        return self.channel.subscribe()
-
-    def subscribe(self, create_task=True):
-        if create_task:
-            self.task = asyncio.ensure_future(self.run())
-        return self.channel.subscribe()
-
-    def _transform_event(self, data):
-        if 'time' in data:
-            data['time'] = dt.datetime.fromtimestamp(data['time'])
-        return data
-
-    async def run(self, **params):
-        if self.json_stream:
-            warnings.warn("already running",
-                          RuntimeWarning, stackelevel=2)
-            return
-        forced_params = {
-            'stream': True,
-        }
-        params = ChainMap(forced_params, params)
-        try:
-            response = await self.docker._query(
-                "events",
-                method="GET",
-                params=params,
-            )
-            self.json_stream = await json_stream_result(
-                response,
-                self._transform_event,
-                human_bool(params['stream']),
-            )
-            try:
-                async for data in self.json_stream:
-                    await self.channel.publish(data)
-            finally:
-                await self.json_stream._close()
-                self.json_stream = None
-        finally:
-            # signal termination to subscribers
-            await self.channel.publish(None)
-
-    async def stop(self):
-        if self.json_stream is not None:
-            await self.json_stream._close()
-        if self.task:
-            self.task.cancel()
-            try:
-                await self.task
-            except asyncio.CancelledError:
-                pass
-
-
-class DockerLog:
-    def __init__(self, docker, container):
-        self.docker = docker
-        self.channel = Channel()
-        self.container = container
-        self.response = None
-
-    def listen(self):
-        warnings.warn("use subscribe() method instead",
-                      DeprecationWarning, stacklevel=2)
-        return self.channel.subscribe()
-
-    def subscribe(self):
-        return self.channel.subscribe()
-
-    async def run(self, **params):
-        if self.response:
-            warnings.warn("already running",
-                          RuntimeWarning, stackelevel=2)
-            return
-        forced_params = {
-            'follow': True,
-        }
-        default_params = {
-            'stdout': True,
-            'stderr': True,
-        }
-        params = ChainMap(forced_params, params, default_params)
-        try:
-            self.response = await self.docker._query(
-                'containers/{self.container._id}/logs'.format(self=self),
-                params=params,
-            )
-            while True:
-                msg = await self.response.content.readline()
-                if not msg:
-                    break
-                await self.channel.publish(msg)
-        except (aiohttp.ClientConnectionError,
-                aiohttp.ServerDisconnectedError):
-            pass
-        finally:
-            # signal termination to subscribers
-            await self.channel.publish(None)
-            try:
-                await self.response.release()
-            except:
-                pass
-            self.response = None
-
-    async def stop(self):
-        if self.response:
-            await self.response.release()
-
-
-class DockerVolumes:
-    def __init__(self, docker):
-        self.docker = docker
-
-    async def list(self):
-        data = await self.docker._query_json("volumes")
-        return data
-
-    async def create(self, config):
-        config = json.dumps(config, sort_keys=True).encode('utf-8')
-        data = await self.docker._query_json(
-            "volumes/create",
-            method="POST",
-            headers={"content-type": "application/json"},
-            data=config,
-        )
-        return DockerVolume(self.docker, data['Name'])
-
-
-class DockerVolume:
-    def __init__(self, docker, name):
-        self.docker = docker
-        self.name = name
-
-    async def show(self):
-        data = await self.docker._query_json(
-            "volumes/{self.name}".format(self=self)
-        )
-        return data
-
-    async def delete(self):
-        response = await self.docker._query(
-            "volumes/{self.name}".format(self=self),
-            method="DELETE",
-        )
-        await response.release()
-        return

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -1,20 +1,16 @@
 import asyncio
-import io
 import json
 import logging
 import os
 from pathlib import Path
 import re
 import ssl
-import tarfile
-import warnings
 
 import aiohttp
 from yarl import URL
 
-from .channel import Channel
 from .jsonstream import json_stream_result
-from .utils import identical, human_bool, httpize, parse_result
+from .utils import httpize, parse_result
 
 # Sub-API classes
 from .containers import DockerContainers, DockerContainer
@@ -33,6 +29,7 @@ __all__ = (
     'DockerEvents',
     'DockerError',
     'DockerImages',
+    'DockerLog',
     'DockerSwarm',
     'DockerServices',
     'DockerTasks',

--- a/aiodocker/events.py
+++ b/aiodocker/events.py
@@ -1,0 +1,71 @@
+import asyncio
+from collections import ChainMap
+import datetime as dt
+import warnings
+
+from .channel import Channel
+from .jsonstream import json_stream_result
+from .utils import human_bool
+
+
+class DockerEvents:
+    def __init__(self, docker):
+        self.docker = docker
+        self.channel = Channel()
+        self.json_stream = None
+        self.task = None
+
+    def listen(self):
+        warnings.warn("use subscribe() method instead",
+                      DeprecationWarning, stacklevel=2)
+        return self.channel.subscribe()
+
+    def subscribe(self, create_task=True):
+        if create_task:
+            self.task = asyncio.ensure_future(self.run())
+        return self.channel.subscribe()
+
+    def _transform_event(self, data):
+        if 'time' in data:
+            data['time'] = dt.datetime.fromtimestamp(data['time'])
+        return data
+
+    async def run(self, **params):
+        if self.json_stream:
+            warnings.warn("already running",
+                          RuntimeWarning, stackelevel=2)
+            return
+        forced_params = {
+            'stream': True,
+        }
+        params = ChainMap(forced_params, params)
+        try:
+            response = await self.docker._query(
+                "events",
+                method="GET",
+                params=params,
+            )
+            self.json_stream = await json_stream_result(
+                response,
+                self._transform_event,
+                human_bool(params['stream']),
+            )
+            try:
+                async for data in self.json_stream:
+                    await self.channel.publish(data)
+            finally:
+                await self.json_stream._close()
+                self.json_stream = None
+        finally:
+            # signal termination to subscribers
+            await self.channel.publish(None)
+
+    async def stop(self):
+        if self.json_stream is not None:
+            await self.json_stream._close()
+        if self.task:
+            self.task.cancel()
+            try:
+                await self.task
+            except asyncio.CancelledError:
+                pass

--- a/aiodocker/images.py
+++ b/aiodocker/images.py
@@ -1,6 +1,7 @@
 import json
 import base64
 from typing import Optional, Union, List, Dict, BinaryIO
+
 from .utils import clean_config
 from .jsonstream import json_stream_result
 

--- a/aiodocker/logs.py
+++ b/aiodocker/logs.py
@@ -1,0 +1,58 @@
+import warnings
+
+from .channel import Channel
+
+
+class DockerLog:
+    def __init__(self, docker, container):
+        self.docker = docker
+        self.channel = Channel()
+        self.container = container
+        self.response = None
+
+    def listen(self):
+        warnings.warn("use subscribe() method instead",
+                      DeprecationWarning, stacklevel=2)
+        return self.channel.subscribe()
+
+    def subscribe(self):
+        return self.channel.subscribe()
+
+    async def run(self, **params):
+        if self.response:
+            warnings.warn("already running",
+                          RuntimeWarning, stackelevel=2)
+            return
+        forced_params = {
+            'follow': True,
+        }
+        default_params = {
+            'stdout': True,
+            'stderr': True,
+        }
+        params = ChainMap(forced_params, params, default_params)
+        try:
+            self.response = await self.docker._query(
+                'containers/{self.container._id}/logs'.format(self=self),
+                params=params,
+            )
+            while True:
+                msg = await self.response.content.readline()
+                if not msg:
+                    break
+                await self.channel.publish(msg)
+        except (aiohttp.ClientConnectionError,
+                aiohttp.ServerDisconnectedError):
+            pass
+        finally:
+            # signal termination to subscribers
+            await self.channel.publish(None)
+            try:
+                await self.response.release()
+            except:
+                pass
+            self.response = None
+
+    async def stop(self):
+        if self.response:
+            await self.response.release()

--- a/aiodocker/logs.py
+++ b/aiodocker/logs.py
@@ -1,4 +1,7 @@
+from collections import ChainMap
 import warnings
+
+import aiohttp
 
 from .channel import Channel
 

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -28,7 +28,7 @@ async def parse_result(response, response_type=None):
                                 .format(ct=ct))
         if 'tar' == response_type:
             what = await response.read()
-            return tarfile.open(mode='r', fileobj=io.BytesIO(what))
+            return tarfile.open(mode='r', fileobj=BytesIO(what))
         if 'json' == response_type:
             data = await response.json(encoding='utf-8')
         elif 'text' == response_type:

--- a/aiodocker/volumes.py
+++ b/aiodocker/volumes.py
@@ -1,3 +1,6 @@
+import json
+
+
 class DockerVolumes:
     def __init__(self, docker):
         self.docker = docker

--- a/aiodocker/volumes.py
+++ b/aiodocker/volumes.py
@@ -1,0 +1,37 @@
+class DockerVolumes:
+    def __init__(self, docker):
+        self.docker = docker
+
+    async def list(self):
+        data = await self.docker._query_json("volumes")
+        return data
+
+    async def create(self, config):
+        config = json.dumps(config, sort_keys=True).encode('utf-8')
+        data = await self.docker._query_json(
+            "volumes/create",
+            method="POST",
+            headers={"content-type": "application/json"},
+            data=config,
+        )
+        return DockerVolume(self.docker, data['Name'])
+
+
+class DockerVolume:
+    def __init__(self, docker, name):
+        self.docker = docker
+        self.name = name
+
+    async def show(self):
+        data = await self.docker._query_json(
+            "volumes/{self.name}".format(self=self)
+        )
+        return data
+
+    async def delete(self):
+        response = await self.docker._query(
+            "volumes/{self.name}".format(self=self),
+            method="DELETE",
+        )
+        await response.release()
+        return


### PR DESCRIPTION
 * It keeps the API compatibility.
 * Later work should base on this structure.