### PR TITLE
Fix: prevents multiple listener tasks to be created automatically

### DIFF
--- a/CHANGES/116.bugfix
+++ b/CHANGES/116.bugfix
@@ -1,0 +1,1 @@
+Fix: prevents multiple listener tasks to be created automatically

--- a/aiodocker/events.py
+++ b/aiodocker/events.py
@@ -21,7 +21,13 @@ class DockerEvents:
         return self.channel.subscribe()
 
     def subscribe(self, *, create_task=True):
-        if create_task:
+        """Subscribes to the Docker events channel. Use the keyword argument
+        create_task=False to prevent automatically spawning the background
+        tasks that listen to the events.
+
+        This function returns a ChannelSubscriber object.
+        """
+        if create_task and not self.task:
             self.task = asyncio.ensure_future(self.run())
         return self.channel.subscribe()
 


### PR DESCRIPTION
## What do these changes do?

Prevents multiple task that listen to events to be created automatically when using `create_task=True` in `docker.events.subscribe()`

## Are there changes in behavior for the user?

Prevents multiple connection being kept and multiple background task.

## Related issue number

#116 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
