### PR TITLE
Gather "application/json" header setup into _query_json() method (#28)

### DIFF
--- a/CHANGES/28.misc
+++ b/CHANGES/28.misc
@@ -1,0 +1,1 @@
+Refactor out scattered setting of content-type to "application/json"

--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -50,7 +50,6 @@ class DockerContainers(object):
         data = await self.docker._query_json(
             url,
             method='POST',
-            headers={"content-type": "application/json"},
             data=config,
             params=kwargs
         )

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -195,7 +195,8 @@ class Docker:
                 'stream': True
             }
         url = self._canonicalize_url(path)
-        url = url.with_query(params)  # ws_connect() does not have params arg.
+        # ws_connect() does not have params arg.
+        url = url.with_query(httpize(params))
         ws = await self.session.ws_connect(
             url,
             protocols=['chat'],

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -150,7 +150,8 @@ class Docker:
                 method, url,
                 params=httpize(params),
                 headers=headers,
-                data=data)
+                data=data,
+                timeout=timeout)
         except asyncio.TimeoutError:
             raise
 
@@ -179,9 +180,8 @@ class Docker:
         if not isinstance(data, (str, bytes)):
             data = json.dumps(data)
         response = await self._query(
-            path,
-            method=method, params=params,
-            data=data, headers=headers,
+            path, method,
+            params=params, data=data, headers=headers,
             timeout=timeout)
         data = await parse_result(response, 'json')
         return data

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -105,7 +105,6 @@ class Docker:
         response = await self._query_json(
             "auth", "POST",
             data=credentials,
-            headers={"content-type": "application/json"},
         )
         return response
 
@@ -134,26 +133,24 @@ class Docker:
         )
         return (await json_stream_result(response, stream=stream))
 
-    def canonicalize_url(self, path, query=None):
-        url = URL("{self.docker_host}/{self.api_version}/{path}"
-                  .format(self=self, path=path))
-        url = url.with_query(httpize(query))
-        return url
+    def _canonicalize_url(self, path):
+        return URL("{self.docker_host}/{self.api_version}/{path}"
+                   .format(self=self, path=path))
 
-    async def _query(self, path, method='GET', params=None, timeout=None,
-                     data=None, headers=None, **kwargs):
+    async def _query(self, path, method='GET', *,
+                     params=None, data=None, headers=None,
+                     timeout=None):
         '''
         Get the response object by performing the HTTP request.
         The caller is responsible to finalize the response object.
         '''
-        url = self.canonicalize_url(path)
-        if timeout is not None:
-            kwargs['timeout'] = timeout
+        url = self._canonicalize_url(path)
         try:
             response = await self.session.request(
                 method, url,
-                params=httpize(params), headers=headers,
-                data=data, **kwargs)
+                params=httpize(params),
+                headers=headers,
+                data=data)
         except asyncio.TimeoutError:
             raise
 
@@ -170,6 +167,25 @@ class Docker:
 
         return response
 
+    async def _query_json(self, path, method='GET', *,
+                          params=None, data=None, headers=None,
+                          timeout=None):
+        '''
+        A shorthand of _query() that treats the input as JSON.
+        '''
+        if headers is None:
+            headers = {}
+        headers['content-type'] = 'application/json'
+        if not isinstance(data, (str, bytes)):
+            data = json.dumps(data)
+        response = await self._query(
+            path,
+            method=method, params=params,
+            data=data, headers=headers,
+            timeout=timeout)
+        data = await parse_result(response, 'json')
+        return data
+
     async def _websocket(self, path, **params):
         if not params:
             params = {
@@ -178,21 +194,15 @@ class Docker:
                 'stderr': True,
                 'stream': True
             }
-        url = self.canonicalize_url(path, query=params)
-        ws = await self.session.ws_connect(url,
-                                           protocols=['chat'],
-                                           origin='http://localhost',
-                                           autoping=True,
-                                           autoclose=True)
+        url = self._canonicalize_url(path)
+        url = url.with_query(params)  # ws_connect() does not have params arg.
+        ws = await self.session.ws_connect(
+            url,
+            protocols=['chat'],
+            origin='http://localhost',
+            autoping=True,
+            autoclose=True)
         return ws
-
-    async def _query_json(self, *args, **kwargs):
-        '''
-        A shorthand of _query() followed by _result() with JSON response type.
-        '''
-        response = await self._query(*args, **kwargs)
-        data = await parse_result(response, 'json')
-        return data
 
     @staticmethod
     def _docker_machine_ssl_context():

--- a/aiodocker/images.py
+++ b/aiodocker/images.py
@@ -16,7 +16,6 @@ class DockerImages(object):
         response = await self.docker._query_json(
             "images/json", "GET",
             params=params,
-            headers={"content-type": "application/json", },
         )
         return response
 
@@ -29,14 +28,12 @@ class DockerImages(object):
         """
         response = await self.docker._query_json(
             "images/{name}/json".format(name=name),
-            headers={"content-type": "application/json", },
         )
         return response
 
     async def history(self, name: str) -> Dict:
         response = await self.docker._query_json(
             "images/{name}/history".format(name=name),
-            headers={"content-type": "application/json", },
         )
         return response
 

--- a/aiodocker/swarm.py
+++ b/aiodocker/swarm.py
@@ -55,7 +55,6 @@ class DockerSwarm(object):
         response = await self.docker._query_json(
             "swarm",
             method='GET',
-            headers={"content-type": "application/json", },
         )
 
         return response

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -16,13 +16,13 @@ async def parse_result(response, response_type=None):
     It also ensures release of the response object.
     '''
     try:
-        if not response_type:
+        if response_type is None:
             ct = response.headers.get("Content-Type", "")
-            if 'json' in ct:
+            if ct.endswith('json'):
                 response_type = 'json'
-            elif 'x-tar' in ct:
+            elif ct.endswith('x-tar'):
                 response_type = 'tar'
-            elif 'text/plain' in ct:
+            elif ct == 'text/plain':
                 response_type = 'text'
             else:
                 raise TypeError("Unrecognized response type: {ct}"

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -22,7 +22,7 @@ async def parse_result(response, response_type=None):
                 response_type = 'json'
             elif ct.endswith('x-tar'):
                 response_type = 'tar'
-            elif ct == 'text/plain':
+            elif ct.startswith('text/plain'):
                 response_type = 'text'
             else:
                 raise TypeError("Unrecognized response type: {ct}"

--- a/aiodocker/volumes.py
+++ b/aiodocker/volumes.py
@@ -14,7 +14,6 @@ class DockerVolumes:
         data = await self.docker._query_json(
             "volumes/create",
             method="POST",
-            headers={"content-type": "application/json"},
             data=config,
         )
         return DockerVolume(self.docker, data['Name'])


### PR DESCRIPTION
## What do these changes do?

Improve the internal beauty.
It cleans up scattered uses of "application/json" headers.

## Are there changes in behavior for the user?

No.

## Related issue number

#28

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
