### PR TITLE
Make auth and image push/pull codes more maintainable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 
 install:
   - docker run -d --privileged --net host --name ci-docker docker:$DOCKER_VERSION-dind dockerd -H tcp://localhost:27015
-  - docker run -d --name registry -p 5000:5000 registry
+  - docker run -d --name registry -p 5000:5000 registry:2
   - docker run -d -p 5001:5001 --name registry2 -v `pwd`/tests/certs:/certs -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/certs/htpasswd -e REGISTRY_HTTP_ADDR=0.0.0.0:5001 -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/registry.crt -e REGISTRY_HTTP_TLS_KEY=/certs/registry.key registry:2
   - pip install -r requirements/ci.txt
 

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -9,7 +9,6 @@ import ssl
 import aiohttp
 from yarl import URL
 
-from .jsonstream import json_stream_result
 from .utils import httpize, parse_result
 
 # Sub-API classes

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -10,7 +10,7 @@ import aiohttp
 from yarl import URL
 
 from .jsonstream import json_stream_result
-from .utils import httpize, parse_result, parse_base64_auth
+from .utils import httpize, parse_result
 
 # Sub-API classes
 from .containers import DockerContainers, DockerContainer
@@ -97,6 +97,10 @@ class Docker:
         self.images = DockerImages(self)
         self.volumes = DockerVolumes(self)
 
+        # legacy aliases
+        self.pull = self.images.pull
+        self.push = self.images.push
+
     async def close(self):
         await self.events.stop()
         await self.session.close()
@@ -112,27 +116,6 @@ class Docker:
         data = await self._query_json("version")
         return data
 
-    # maybe discard future
-    async def pull(self, image, auth=None, stream=False):
-
-        headers = {"content-type": "application/json"}
-        if auth:
-            if isinstance(auth, dict) and 'auth' in auth:
-                registry, has_registry_host, _ = image.partition('/')
-                if not has_registry_host:
-                    raise ValueError(" image should have registry host")
-                auth_header = parse_base64_auth(auth['auth'], registry)
-                headers.update({"X-Registry-Auth": auth_header})
-            else:
-                raise ValueError(" auth format error " + str(auth))
-
-        response = await self._query(
-            "images/create", "POST",
-            params={"fromImage": image},
-            headers=headers
-        )
-        return (await json_stream_result(response, stream=stream))
-
     def _canonicalize_url(self, path):
         return URL("{self.docker_host}/{self.api_version}/{path}"
                    .format(self=self, path=path))
@@ -145,6 +128,8 @@ class Docker:
         The caller is responsible to finalize the response object.
         '''
         url = self._canonicalize_url(path)
+        if headers and 'content-type' not in headers:
+            headers['content-type'] = 'application/json'
         try:
             response = await self.session.request(
                 method, url,
@@ -154,7 +139,6 @@ class Docker:
                 timeout=timeout)
         except asyncio.TimeoutError:
             raise
-
         if (response.status // 100) in [4, 5]:
             what = await response.read()
             content_type = response.headers.get('content-type', '')
@@ -165,7 +149,6 @@ class Docker:
             else:
                 raise DockerError(response.status,
                                   {"message": what.decode('utf8')})
-
         return response
 
     async def _query_json(self, path, method='GET', *,

--- a/aiodocker/images.py
+++ b/aiodocker/images.py
@@ -1,5 +1,9 @@
 import json
-from typing import Optional, Union, List, Mapping, BinaryIO
+from typing import (
+    Optional, Union,
+    List, MutableMapping, Mapping,
+    BinaryIO,
+)
 from .utils import clean_map, compose_auth_header
 from .jsonstream import json_stream_result
 
@@ -37,7 +41,7 @@ class DockerImages(object):
         return response
 
     async def pull(self, from_image: str, *,
-                   auth: Optional[Union[Mapping, str, bytes]]=None,
+                   auth: Optional[Union[MutableMapping, str, bytes]]=None,
                    tag: Optional[str]=None,
                    repo: Optional[str]=None,
                    stream: bool=False) -> Mapping:
@@ -76,7 +80,7 @@ class DockerImages(object):
         return (await json_stream_result(response, stream=stream))
 
     async def push(self, name: str, *,
-                   auth: Union[Mapping, str, bytes]=None,
+                   auth: Union[MutableMapping, str, bytes]=None,
                    tag: Optional[str]=None,
                    stream: bool=False) -> Mapping:
         params = {}

--- a/aiodocker/images.py
+++ b/aiodocker/images.py
@@ -1,5 +1,4 @@
 import json
-import base64
 from typing import Optional, Union, List, Mapping, BinaryIO
 from .utils import clean_map, compose_auth_header
 from .jsonstream import json_stream_result
@@ -75,8 +74,6 @@ class DockerImages(object):
             headers=headers,
         )
         return (await json_stream_result(response, stream=stream))
-
-    # TODO: create_from_source(...)
 
     async def push(self, name: str, *,
                    auth: Union[Mapping, str, bytes]=None,

--- a/aiodocker/images.py
+++ b/aiodocker/images.py
@@ -1,7 +1,7 @@
 import json
 import base64
-from typing import Optional, Union, List, Dict, BinaryIO
-from .utils import clean_map, parse_base64_auth
+from typing import Optional, Union, List, Mapping, BinaryIO
+from .utils import clean_map, compose_auth_header
 from .jsonstream import json_stream_result
 
 
@@ -9,7 +9,7 @@ class DockerImages(object):
     def __init__(self, docker):
         self.docker = docker
 
-    async def list(self, **params) -> Dict:
+    async def list(self, **params) -> Mapping:
         """
         List of images
         """
@@ -19,7 +19,7 @@ class DockerImages(object):
         )
         return response
 
-    async def get(self, name: str) -> Dict:
+    async def get(self, name: str) -> Mapping:
         """
         Return low-level information about an image
 
@@ -31,15 +31,17 @@ class DockerImages(object):
         )
         return response
 
-    async def history(self, name: str) -> Dict:
+    async def history(self, name: str) -> Mapping:
         response = await self.docker._query_json(
             "images/{name}/history".format(name=name),
         )
         return response
 
-    async def pull(self, from_image: str, *, repo: Optional[str]=None,
-                   tag: Optional[str]=None, auth: Optional[dict]=None,
-                   stream: bool=False) -> Dict:
+    async def pull(self, from_image: str, *,
+                   auth: Optional[Union[Mapping, str, bytes]]=None,
+                   tag: Optional[str]=None,
+                   repo: Optional[str]=None,
+                   stream: bool=False) -> Mapping:
         """
         Similar to `docker pull`, pull an image locally
 
@@ -50,24 +52,22 @@ class DockerImages(object):
                  for the given image to be pulled
             auth: special {'auth': base64} pull private repo
         """
-
-        params = {}
-
-        if from_image:
-            params['fromImage'] = from_image
-
+        image = from_image  # TODO: clean up
+        params = {
+            'fromImage': image,
+        }
+        headers = {}
         if repo:
             params['repo'] = repo
-
         if tag:
             params['tag'] = tag
-
-        headers = {"content-type": "application/json"}
-
-        if auth and 'auth' in auth:
-            auth_header = parse_base64_auth(auth['auth'], repo)
-            headers.update({"X-Registry-Auth": auth_header})
-
+        if auth is not None:
+            registry, has_registry_host, _ = image.partition('/')
+            if not has_registry_host:
+                raise ValueError('Image should have registry host '
+                                 'when auth information is provided')
+            # TODO: assert registry == repo?
+            headers['X-Registry-Auth'] = compose_auth_header(auth, registry)
         response = await self.docker._query(
             "images/create",
             "POST",
@@ -76,26 +76,25 @@ class DockerImages(object):
         )
         return (await json_stream_result(response, stream=stream))
 
-    async def push(self, name: str, *, tag: Optional[str]=None,
-                   auth: Union[Dict, str, bytes]=None,
-                   stream: bool=False) -> Dict:
-        headers = {
-            "content-type": "application/json",
-            "X-Registry-Auth": "FOO",
-        }
+    # TODO: create_from_source(...)
+
+    async def push(self, name: str, *,
+                   auth: Union[Mapping, str, bytes]=None,
+                   tag: Optional[str]=None,
+                   stream: bool=False) -> Mapping:
         params = {}
-        if auth:
-            if isinstance(auth, dict):
-                auth = json.dumps(auth).encode('ascii')
-                auth = base64.b64encode(auth)
-            if not isinstance(auth, (bytes, str)):
-                raise TypeError(
-                    "auth must be base64 encoded string/bytes or a dictionary")
-            if isinstance(auth, bytes):
-                auth = auth.decode('ascii')
-            headers['X-Registry-Auth'] = auth
+        headers = {
+            # Anonymous push requires a dummy auth header.
+            'X-Registry-Auth': 'placeholder',
+        }
         if tag:
             params['tag'] = tag
+        if auth is not None:
+            registry, has_registry_host, _ = name.partition('/')
+            if not has_registry_host:
+                raise ValueError('Image should have registry host '
+                                 'when auth information is provided')
+            headers['X-Registry-Auth'] = compose_auth_header(auth, registry)
         response = await self.docker._query(
             "images/{name}/push".format(name=name),
             "POST",
@@ -156,13 +155,13 @@ class DockerImages(object):
                     tag: Optional[str]=None,
                     quiet: bool=False,
                     nocache: bool=False,
-                    buildargs: Optional[Dict]=None,
+                    buildargs: Optional[Mapping]=None,
                     pull: bool=False,
                     rm: bool=True,
                     forcerm: bool=False,
-                    labels: Optional[Dict]=None,
+                    labels: Optional[Mapping]=None,
                     stream: bool=False,
-                    encoding: Optional[str]=None) -> Dict:
+                    encoding: Optional[str]=None) -> Mapping:
         """
         Build an image given a remote Dockerfile
         or a file object with a Dockerfile inside

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -287,7 +287,7 @@ def compose_auth_header(auth: Union[Mapping, str, bytes],
             "serveraddress": registry_addr,
         }
         auth_json = json.dumps(config).encode('utf-8')
-        auth = base64.urlsafe_b64encode(auth_json).decode('ascii')
+        auth = base64.b64encode(auth_json).decode('ascii')
     else:
         raise TypeError(
             "auth must be base64 encoded string/bytes or a dictionary")

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -5,7 +5,7 @@ from io import BytesIO
 import sys
 from typing import (
     Any, Iterable, Optional, Union,
-    Mapping, Tuple,
+    MutableMapping, Mapping, Tuple,
     BinaryIO, IO,
 )
 import tempfile
@@ -244,7 +244,7 @@ def mktar_from_dockerfile(fileobject: BinaryIO) -> IO:
     return f
 
 
-def compose_auth_header(auth: Union[Mapping, str, bytes],
+def compose_auth_header(auth: Union[MutableMapping, str, bytes],
                         registry_addr: Optional[str]=None) -> str:
     """
     Validate and compose base64-encoded authentication header


### PR DESCRIPTION
## What do these changes do?

Make existing auth/push/pull codes more maintainable.

## Are there changes in behavior for the user?

No visible changes, but it relieves some restriction on how you can give the `auth` arguments to `DockerImages.push()` method -- now it allows already-encoded strings.

## Related issue number

This improves #102.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] I'm already at CONTRIBUTORS.
- [ ] Add a new news fragment into the `changes` folder
