### PR TITLE
Handle responses with 0 or missing Content-Length

### DIFF
--- a/CHANGES/237.bugfix
+++ b/CHANGES/237.bugfix
@@ -1,0 +1,1 @@
+Fix: Handle responses with 0 or missing Content-Length

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,4 +1,5 @@
 Alkim Gozen
+Andrew Gaul
 Andrew Svetlov
 Anton Patrushev
 Byeongjun Park

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -23,7 +23,10 @@ async def parse_result(response, response_type=None, *,
     if response_type is None:
         ct = response.headers.get('content-type')
         if ct is None:
-            raise TypeError('Cannot auto-detect respone type '
+            cl = response.headers.get('content-length')
+            if cl is None or cl == '0':
+                return ''
+            raise TypeError('Cannot auto-detect response type '
                             'due to missing Content-Type header.')
         main_type, sub_type, extras = parse_content_type(ct)
         if sub_type == 'json':


### PR DESCRIPTION
Previously `utils.py:parse_result` failed with:

> TypeError: Cannot auto-detect response type due to missing
> Content-Type header.

Observed these symptoms with 18.06.0-ce, build 0ffa825 when calling
`containers.py:put_archive`.

Also fix typo in error message.  Fixes #237.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
