### PR TITLE
Add ability to get a Docker network by name or ID

### DIFF
--- a/CHANGES/279.feature
+++ b/CHANGES/279.feature
@@ -1,0 +1,1 @@
+Add ability to get a Docker network by name or ID.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -11,6 +11,7 @@ Igor Alexandrov
 Jason Kraus
 Joongi Kim
 Joshua Chung
+Julien Kmec
 Martin Koppehel
 Nikolay Novik
 Paul Tagliamonte

--- a/aiodocker/networks.py
+++ b/aiodocker/networks.py
@@ -16,6 +16,12 @@ class DockerNetworks:
         )
         return DockerNetwork(self.docker, data["Id"])
 
+    async def get(self, net_specs):
+        data = await self.docker._query_json(
+            "networks/{net_specs}".format(net_specs=net_specs), method="GET",
+        )
+        return DockerNetwork(self.docker, data["Id"])
+
 
 class DockerNetwork:
     def __init__(self, docker, id_):

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -13,6 +13,8 @@ async def test_list_networks(docker):
 @pytest.mark.asyncio
 async def test_networks(docker):
     network = await docker.networks.create({"Name": "test-net"})
+    net_find = await docker.networks.get("test-net")
+    assert (await net_find.show())["Name"] == "test-net"
     assert isinstance(network, aiodocker.networks.DockerNetwork)
     data = await network.show()
     assert data["Name"] == "test-net"


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

This pull request adds the ability to get a Docker network by name or ID.

## Are there changes in behavior for the user?

This change adds a new method: docker.networks.get("network name or ID").

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
