### PR TITLE
Implement the ability to use docker exec.

### DIFF
--- a/CHANGES/174.feature
+++ b/CHANGES/174.feature
@@ -1,0 +1,1 @@
+Add support for `docker exec` (issuing commands in a running container).

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -16,4 +16,5 @@ Martin Koppehel
 Nikolay Novik
 Paul Tagliamonte
 Tianon Gravi
+Tommy Beadle
 Travis DePrato

--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -2,6 +2,7 @@ import json
 import tarfile
 
 from .exceptions import DockerError, DockerContainerError
+from .execute import Exec
 from .jsonstream import json_stream_result
 from .multiplexed import multiplexed_result
 from .utils import identical, parse_result
@@ -208,6 +209,11 @@ class DockerContainer:
         path = "containers/{self._id}/attach/ws".format(self=self)
         ws = await self.docker._websocket(path, **params)
         return ws
+
+    async def exec_create(self, **kwargs) -> Exec:
+        """ Create an exec (Instance of Exec).
+        """
+        return await Exec.create(self, **kwargs)
 
     async def port(self, private_port):
         if "NetworkSettings" not in self._container:

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -142,7 +142,8 @@ class Docker:
         data=None,
         headers=None,
         timeout=None,
-        chunked=None
+        chunked=None,
+        read_until_eof=True
     ):
         """
         Get the response object by performing the HTTP request.
@@ -160,6 +161,7 @@ class Docker:
                 data=data,
                 timeout=timeout,
                 chunked=chunked,
+                read_until_eof=read_until_eof,
             )
         except asyncio.TimeoutError:
             raise

--- a/aiodocker/execute.py
+++ b/aiodocker/execute.py
@@ -1,0 +1,228 @@
+import json
+import struct
+from typing import cast, Any, Dict, List, Optional, TYPE_CHECKING, Union
+
+from aiohttp import ClientWebSocketResponse, WSMessage, WSMsgType, FlowControlDataQueue
+from aiohttp.http_websocket import WebSocketWriter
+
+if TYPE_CHECKING:
+    from .containers import DockerContainer
+
+# When a Tty is allocated for an "exec" operation, the stdout and stderr are streamed
+# straight to the client.
+# When a Tty is NOT allocated, then stdout and stderr are multiplexed using the format
+# given at
+# https://docs.docker.com/engine/api/v1.40/#operation/ContainerAttach under the "Stream
+# Format" heading. Note that that documentation is for "docker attach" but the format
+# also applies to "docker exec."
+
+STDOUT = 1
+STDERR = 2
+
+
+class ExecReader:
+    def __init__(self, queue, tty=False):
+        self.queue = queue
+        self.tty = tty
+        self._exc = None
+        self.header_fmt = struct.Struct(">BxxxL")
+
+    def feed_eof(self):
+        self.queue.feed_eof()
+
+    def feed_data(self, data):
+        if self._exc:
+            return True, data
+
+        try:
+            # Wrap with WSMessage to deceive ClientWebSocketResponse
+            if self.tty:
+                msg = WSMessage(WSMsgType.BINARY, data, STDOUT)
+                self.queue.feed_data(msg, len(data))
+            else:
+                while data:
+                    # Parse the header
+                    if len(data) < self.header_fmt.size:
+                        raise IOError("Not enough data was received to parse header.")
+                    fileno, msglen = self.header_fmt.unpack(
+                        data[: self.header_fmt.size]
+                    )
+                    msg_and_header = self.header_fmt.size + msglen
+                    if len(data) < msg_and_header:
+                        raise IOError(
+                            "Not enough data was received to contain the payload."
+                        )
+                    msg = WSMessage(
+                        WSMsgType.BINARY,
+                        data[self.header_fmt.size:msg_and_header],
+                        fileno,
+                    )
+                    self.queue.feed_data(msg, msglen)
+                    data = data[msg_and_header:]
+            return False, b""
+        except Exception as exc:
+            self._exc = exc
+            self.queue.set_exception(exc)
+            return True, b""
+
+
+class ExecWriter:
+    def __init__(self, transport):
+        self.transport = transport
+
+    async def send(self, message, *args, **kwargs):
+        if isinstance(message, str):
+            message = message.encode("utf-8")
+        self.transport.write(message)
+
+    def write_eof(self):
+        self.transport.write_eof()
+
+    async def close(self, code=1000, message=b""):
+        self.write_eof()
+        return None
+
+
+class Exec:
+    def __init__(self, exec_id, container):
+        self.exec_id = exec_id
+        self.container = container
+
+    @classmethod
+    async def create(
+        cls,
+        container,  # type: DockerContainer
+        AttachStdin: Optional[bool] = None,
+        AttachStdout: Optional[bool] = None,
+        AttachStderr: Optional[bool] = None,
+        DetachKeys: Optional[str] = None,
+        Tty: Optional[bool] = None,
+        Env: Optional[List[str]] = None,
+        Cmd: Union[None, str, List[str]] = None,
+        Privileged: Optional[bool] = None,
+        User: Optional[str] = None,
+        WorkingDir: Optional[str] = None,
+    ) -> "Exec":
+        """ Create and return an instance of Exec. See
+        https://docs.docker.com/engine/api/v1.40/#operation/ContainerExec for
+        information on the available parameters.
+        """
+        kwargs = {}
+        for name in (
+            "AttachStdin",
+            "AttachStdout",
+            "AttachStderr",
+            "DetachKeys",
+            "Tty",
+            "Env",
+            "Cmd",
+            "Privileged",
+            "User",
+            "WorkingDir",
+        ):
+            val = locals()[name]
+            if val is not None:
+                kwargs[name] = val
+        data = await container.docker._query_json(
+            "containers/{container._id}/exec".format(container=container),
+            method="POST",
+            data=kwargs,
+        )
+        return cls(data["Id"], container)
+
+    async def start(
+        self,
+        timeout: int = 10,
+        receive_timeout: Optional[int] = None,
+        Detach: bool = False,
+        Tty: bool = False,
+    ) -> Union[ClientWebSocketResponse, bytes]:
+        """
+        Start this exec instance.
+
+        Args:
+            timeout: The timeout in seconds for the request to start the exec instance.
+            receive_timeout: The timeout in seconds that will be allowing when
+                attempting to read from the output stream of the instance.
+            Detach: Indicates whether we should detach from the command (like the `-d`
+                option to `docker exec`).
+            Tty: Indicates whether a TTY should be allocated (like the `-t` option to
+                `docker exec`).
+
+        Returns:
+            If `Detach` is `True`, this method will return the result of the exec
+            process as a binary string.
+            If `Detach` is False, an `aiohttp.ClientWebSocketResponse` will be returned.
+            You can use it to send and receive data the same wa as the response of
+            "ws_connect" of aiohttp. If `Tty` is `False`, then the messages returned
+            from `receive*` will have their `extra` attribute set to 1 if the data was
+            from stdout or 2 if from stderr.
+        """
+        # Don't use docker._query_json
+        # content-type of response will be "vnd.docker.raw-stream",
+        # so it will cause error.
+        response = await self.container.docker._query(
+            "exec/{exec_id}/start".format(exec_id=self.exec_id),
+            method="POST",
+            headers={
+                "content-type": "application/json",
+                "Connection": "Upgrade",
+                "Upgrade": "TCP",
+            },
+            data=json.dumps({"Detach": Detach, "Tty": Tty}),
+            read_until_eof=Detach,
+            timeout=timeout,
+        )
+
+        if not Detach:
+            conn = response.connection
+            transport = conn.transport
+            protocol = conn.protocol
+            loop = response._loop
+
+            reader = FlowControlDataQueue(
+                protocol, limit=2 ** 16, loop=loop
+            )  # type: FlowControlDataQueue[WSMessage]
+            writer = ExecWriter(transport)
+            protocol.set_parser(ExecReader(reader, tty=Tty), reader)
+            return ClientWebSocketResponse(
+                reader,
+                cast(WebSocketWriter, writer),
+                None,  # protocol
+                response,
+                timeout,
+                True,  # autoclose
+                False,  # autoping
+                loop,
+                receive_timeout=receive_timeout,
+            )
+
+        else:
+            result = await response.read()
+            await response.release()
+            return result
+
+    async def resize(self, h: Optional[int] = None, w: Optional[int] = None):
+        """ Resize the size of the TTY being used for the exec instance.
+
+        Args:
+            h: The desired height of the TTY in characters.
+            w: The desired width of the TTY in characters.
+        """
+        kwargs = {}
+        if h is not None:
+            kwargs["h"] = h
+        if w is not None:
+            kwargs["w"] = w
+        await self.container.docker._query(
+            "exec/{exec_id}/resize".format(exec_id=self.exec_id),
+            method="POST",
+            params=kwargs,
+        )
+
+    async def inspect(self) -> Dict[str, Any]:
+        """ Return low-level information about an exec instance. """
+        data = await self.container.docker._query_json(
+            "exec/{exec_id}/json".format(exec_id=self.exec_id), method="GET"
+        )
+        return data

--- a/docs/exec.rst
+++ b/docs/exec.rst
@@ -1,0 +1,13 @@
+====
+Exec
+====
+
+------------
+Reference
+------------
+
+Exec
+====
+.. autoclass:: aiodocker.execute.Exec
+        :members:
+        :undoc-members:

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -97,3 +97,14 @@ async def test_restart(docker):
         await container.stop()
     finally:
         await container.delete(force=True)
+
+
+@pytest.mark.asyncio
+async def test_exec(shell_container):
+    execute = await shell_container.exec_create(
+        AttachStdout=True, AttachStderr=True,
+        AttachStdin=True, Tty=True,
+        Cmd=['echo', 'Hello'],
+    )
+    resp = await execute.start(Detach=False, Tty=True)
+    assert await resp.receive_bytes() == b"Hello\r\n"

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,0 +1,63 @@
+import pytest
+
+from aiohttp import WSMsgType, ClientWebSocketResponse
+from aiodocker.execute import STDOUT, STDERR
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("detach", [True, False], ids=lambda x: "detach={}".format(x))
+@pytest.mark.parametrize("tty", [True, False], ids=lambda x: "tty={}".format(x))
+@pytest.mark.parametrize("stderr", [True, False], ids=lambda x: "stderr={}".format(x))
+async def test_exec_start_stream(shell_container, detach, tty, stderr):
+    if detach:
+        cmd = "echo -n Hello".split()
+    else:
+        cmd = ["cat"]
+    if stderr:
+        cmd = ["sh", "-c", " ".join(cmd) + " >&2"]
+    execute = await shell_container.exec_create(
+        AttachStdout=True, AttachStderr=True, AttachStdin=True, Tty=tty, Cmd=cmd
+    )
+    resp = await execute.start(Detach=detach, Tty=tty)
+    if detach:
+        assert isinstance(resp, bytes)
+        assert resp == b""
+    else:
+        assert isinstance(resp, ClientWebSocketResponse)
+        hello = b"Hello"
+        await resp.send_bytes(hello)
+        msg = await resp.receive()
+        assert msg.data == hello
+        # We can't use sys.stdout.fileno() and sys.stderr.fileno() in the test because
+        # pytest changes that so it can capture output.
+        assert msg.extra == (STDOUT if tty or not stderr else STDERR)
+
+
+@pytest.mark.asyncio
+async def test_exec_resize(shell_container):
+    execute = await shell_container.exec_create(
+        AttachStdout=True,
+        AttachStderr=True,
+        AttachStdin=True,
+        Tty=True,
+        Cmd=["/bin/ash"],
+    )
+    await execute.start(Detach=False, Tty=True)
+    await execute.resize(h=10, w=80)
+
+
+@pytest.mark.asyncio
+async def test_exec_inspect(shell_container):
+    execute = await shell_container.exec_create(
+        AttachStdout=True,
+        AttachStderr=True,
+        AttachStdin=True,
+        Tty=True,
+        Cmd=["echo", "Hello"],
+    )
+    resp = await execute.start(Detach=False, Tty=True)
+    assert (await resp.receive()).data == b"Hello\r\n"
+    assert (await resp.receive()).type == WSMsgType.CLOSED
+    assert resp.closed
+    data = await execute.inspect()
+    assert data["ExitCode"] == 0

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,14 @@ envlist =
     mypy,
     py35
     py36
+    py37
 skipsdist=True
 
 [travis]
 python =
 	3.5: py35, flake8, mypy
 	3.6: py36, flake8, mypy
+	3.7: py37, flake8, mypy
 
 [testenv]
 passenv=DOCKER_HOST DOCKER_VERSION


### PR DESCRIPTION
## What do these changes do?

This builds on the great work in
https://github.com/hirokiky/aiodocker/commits/feature-exec-run for allowing a user to issue commands in a currently running container (i.e. `docker exec`). It
improves how stdout and stderr are handled so that, when a Tty is not
used, we can handle the multiplexing that is done by the docker daemon
when writing from the websocket. It includes information on whether the
data is from stdout or stderr. We can include that information in the
messages we create.
If a Tty is used, it treats all data as coming from stdout because
docker can not make any distinction between streams in that case.

We can also get rid of the `stream` argument and just use `Detach`. If
`Detach` is True, we just return with any output of doing that, which is
probably (maybe always) going to be empty.
If `Detach` is False, then we'll create the ClientWebSocketResponse
object that can be used to read from/write to the process.

## Are there changes in behavior for the user?

This is a new feature and does not contain any backwards-incompatible changes.

## Related issue number

#174 

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [X] Add a new news fragment into the `changes` folder