### PR TITLE
Fix streaming mode

### DIFF
--- a/CHANGES/344.bugfix
+++ b/CHANGES/344.bugfix
@@ -1,0 +1,1 @@
+Fix streaming mode for pull, push, build, stats and events.

--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -230,7 +230,7 @@ class DockerContainer:
 
         return h_ports
 
-    async def stats(self, *, stream=True):
+    def stats(self, *, stream=True):
         cm = self.docker._query(
             "containers/{self._id}/stats".format(self=self),
             params={"stream": "1" if stream else "0"},

--- a/aiodocker/events.py
+++ b/aiodocker/events.py
@@ -5,7 +5,6 @@ from collections import ChainMap
 
 from .channel import Channel
 from .jsonstream import json_stream_stream
-from .utils import human_bool
 
 
 class DockerEvents:
@@ -48,7 +47,6 @@ class DockerEvents:
             return
         forced_params = {"stream": True}
         params = ChainMap(forced_params, params)
-        stream = human_bool(params["stream"])
         try:
             # timeout has to be set to 0, None is not passed
             # Otherwise after 5 minutes the client

--- a/aiodocker/events.py
+++ b/aiodocker/events.py
@@ -4,7 +4,7 @@ import warnings
 from collections import ChainMap
 
 from .channel import Channel
-from .jsonstream import json_stream_result
+from .jsonstream import json_stream_stream
 from .utils import human_bool
 
 
@@ -48,6 +48,7 @@ class DockerEvents:
             return
         forced_params = {"stream": True}
         params = ChainMap(forced_params, params)
+        stream = human_bool(params["stream"])
         try:
             # timeout has to be set to 0, None is not passed
             # Otherwise after 5 minutes the client
@@ -56,9 +57,7 @@ class DockerEvents:
             async with self.docker._query(
                 "events", method="GET", params=params, timeout=0
             ) as response:
-                self.json_stream = await json_stream_result(
-                    response, self._transform_event, human_bool(params["stream"])
-                )
+                self.json_stream = json_stream_stream(response, self._transform_event)
                 try:
                     async for data in self.json_stream:
                         await self.channel.publish(data)

--- a/aiodocker/images.py
+++ b/aiodocker/images.py
@@ -88,7 +88,7 @@ class DockerImages(object):
 
     async def _handle_stream(self, cm):
         async with cm as response:
-            for item in json_stream_stream(response):
+            async for item in json_stream_stream(response):
                 yield item
 
     async def _handle_list(self, cm):

--- a/aiodocker/jsonstream.py
+++ b/aiodocker/jsonstream.py
@@ -43,11 +43,13 @@ class _JsonStreamResult:
         self._response.close()
 
 
-async def json_stream_result(response, transform=None, stream=True):
+def json_stream_stream(response, transform=None):
     json_stream = _JsonStreamResult(response, transform)
+    return json_stream
 
-    if stream:
-        return json_stream
+
+async def json_stream_list(response, transform=None):
+    json_stream = _JsonStreamResult(response, transform)
 
     data = []
     async for obj in json_stream:

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -118,7 +118,7 @@ async def test_container_stats_list(docker):
         response = await container.wait()
         assert response["StatusCode"] == 0
         stats = await container.stats(stream=False)
-        assert 'cpu_stats' in stats[0]
+        assert "cpu_stats" in stats[0]
     finally:
         await container.delete(force=True)
 
@@ -136,7 +136,7 @@ async def test_container_stats_stream(docker):
         assert response["StatusCode"] == 0
         count = 0
         async for stat in container.stats():
-            assert 'cpu_stats' in stat
+            assert "cpu_stats" in stat
             count += 1
             if count > 3:
                 break

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -104,3 +104,41 @@ async def test_restart(docker):
         await container.stop()
     finally:
         await container.delete(force=True)
+
+
+@pytest.mark.asyncio
+async def test_container_stats_list(docker):
+    name = "python:latest"
+    container = await docker.containers.run(
+        config={"Cmd": ["-c", "print('hello')"], "Entrypoint": "python", "Image": name}
+    )
+
+    try:
+        await container.start()
+        response = await container.wait()
+        assert response["StatusCode"] == 0
+        stats = await container.stats(stream=False)
+        assert 'cpu_stats' in stats[0]
+    finally:
+        await container.delete(force=True)
+
+
+@pytest.mark.asyncio
+async def test_container_stats_stream(docker):
+    name = "python:latest"
+    container = await docker.containers.run(
+        config={"Cmd": ["-c", "print('hello')"], "Entrypoint": "python", "Image": name}
+    )
+
+    try:
+        await container.start()
+        response = await container.wait()
+        assert response["StatusCode"] == 0
+        count = 0
+        async for stat in container.stats():
+            assert 'cpu_stats' in stat
+            count += 1
+            if count > 3:
+                break
+    finally:
+        await container.delete(force=True)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -122,7 +122,7 @@ async def test_pull_image(docker):
 
     with pytest.warns(DeprecationWarning):
         image = await docker.images.get(name=name)
-        assert image
+        assert 'Architecture' in image
 
 
 @pytest.mark.asyncio

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -87,6 +87,15 @@ async def test_push_image(docker):
 
 
 @pytest.mark.asyncio
+async def test_push_image_stream(docker):
+    name = "python:latest"
+    repository = "localhost:5000/image"
+    await docker.images.tag(name=name, repo=repository)
+    async for item in docker.images.push(name=repository, stream=True):
+        pass
+
+
+@pytest.mark.asyncio
 async def test_delete_image(docker):
     name = "python:latest"
     repository = "localhost:5000/image"
@@ -114,6 +123,16 @@ async def test_pull_image(docker):
     with pytest.warns(DeprecationWarning):
         image = await docker.images.get(name=name)
         assert image
+
+
+@pytest.mark.asyncio
+async def test_pull_image_stream(docker):
+    name = "python:latest"
+    image = await docker.images.inspect(name=name)
+    assert image
+
+    async for item in docker.images.pull(name, stream=True):
+        pass
 
 
 @pytest.mark.asyncio

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -122,7 +122,7 @@ async def test_pull_image(docker):
 
     with pytest.warns(DeprecationWarning):
         image = await docker.images.get(name=name)
-        assert 'Architecture' in image
+        assert "Architecture" in image
 
 
 @pytest.mark.asyncio
@@ -145,6 +145,24 @@ async def test_build_from_tar(docker, random_name):
     f = BytesIO(dockerfile.encode("utf-8"))
     tar_obj = utils.mktar_from_dockerfile(f)
     await docker.images.build(fileobj=tar_obj, encoding="gzip", tag=name)
+    tar_obj.close()
+    image = await docker.images.inspect(name=name)
+    assert image
+
+
+@pytest.mark.asyncio
+async def test_build_from_tar_stream(docker, random_name):
+    name = "{}:latest".format(random_name())
+    dockerfile = """
+    # Shared Volume
+    FROM python:latest
+    """
+    f = BytesIO(dockerfile.encode("utf-8"))
+    tar_obj = utils.mktar_from_dockerfile(f)
+    async for item in docker.images.build(
+        fileobj=tar_obj, encoding="gzip", tag=name, stream=True
+    ):
+        pass
     tar_obj.close()
     image = await docker.images.inspect(name=name)
     assert image

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -134,8 +134,10 @@ async def test_build_from_tar(docker, random_name):
 @pytest.mark.asyncio
 async def test_export_image(docker):
     name = "python:latest"
-    exported_image = await docker.images.export_image(name=name)
-    assert exported_image
+    async with docker.images.export_image(name=name) as exported_image:
+        assert exported_image
+        async for chunk in exported_image.iter_chunks():
+            pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Sorry, `aiodocker==0.15` is broken for streaming mode, e.g. `docker.pull(..., stream=True)`.
Our test suite doesn't cover the case well.