### PR TITLE
Do not store whole tar inside RAM

### DIFF
--- a/CHANGES/352.bugfix
+++ b/CHANGES/352.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue when the entire tar archive was stored in RAM while building the image.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -12,6 +12,7 @@ Jason Kraus
 Joongi Kim
 Joshua Chung
 Julien Kmec
+Konstantin Valetov
 Martin Koppehel
 Nikolay Novik
 Paul Tagliamonte


### PR DESCRIPTION
## What do these changes do?

Fixed an issue when the entire tar archive was stored in RAM while building the image.

## Are there changes in behavior for the user?

No.

## Related issue number

#352 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
