### PR TITLE
Rename websocket() to attach()

### DIFF
--- a/CHANGES/412.feature
+++ b/CHANGES/412.feature
@@ -1,0 +1,1 @@
+Rename `websocket()` to `attach()`

--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -203,10 +203,12 @@ class DockerContainer:
         ):
             pass
 
-    async def websocket(self, **params):
+    async def attach(self, **params):
         path = "containers/{self._id}/attach/ws".format(self=self)
         ws = await self.docker._websocket(path, **params)
         return ws
+
+    websocket = attach
 
     async def port(self, private_port):
         if "NetworkSettings" not in self._container:

--- a/docs/containers.rst
+++ b/docs/containers.rst
@@ -1,9 +1,9 @@
-===============
-Containers 
-===============
+==========
+Containers
+==========
 
 Create a container
-========================
+==================
 
 .. code-block:: python
 
@@ -33,19 +33,18 @@ Create a container
        loop.run_until_complete(create_container())
        loop.close()
 
-------------
+---------
 Reference
-------------
+---------
 
 DockerContainers
-==================
+================
 .. autoclass:: aiodocker.docker.DockerContainers
         :members:
         :undoc-members:
 
 DockerContainer
-==================
+===============
 .. autoclass:: aiodocker.docker.DockerContainer
         :members:
         :undoc-members:
-


### PR DESCRIPTION
Keep `websocket()` as a deprecated alias.