### PR TITLE
Fix indentation in services.rst

### DIFF
--- a/docs/services.rst
+++ b/docs/services.rst
@@ -17,14 +17,14 @@ Create a service
        "ContainerSpec": {
            "Image": "redis",
            },
-    }
+   }
 
-    async def create_service():
-        service = await docker.services.create(
-                            task_template=TaskTemplate,
-                            name="my_service"
-                            )
-        await docker.close()
+   async def create_service():
+       service = await docker.services.create(
+           task_template=TaskTemplate,
+           name="my_service"
+       )
+       await docker.close()
 
 
    if __name__ == '__main__':


### PR DESCRIPTION
The example indentation was off by 1 character.

> If this is a bug fix or documentation amendment, select the latest release branch (which looks like "0.xx")

I can't seem to find that branch – please adjust if needed.