### PR TITLE
Close task events

### DIFF
--- a/CHANGES/447.bugfix
+++ b/CHANGES/447.bugfix
@@ -1,1 +1,0 @@
-Fix close of the event task

--- a/CHANGES/447.bugfix
+++ b/CHANGES/447.bugfix
@@ -1,0 +1,1 @@
+Fix close of the event task

--- a/CHANGES/448.bugfix
+++ b/CHANGES/448.bugfix
@@ -1,0 +1,1 @@
+Fix closing of the task fetching Docker's event stream and make it re-openable after closing

--- a/aiodocker/events.py
+++ b/aiodocker/events.py
@@ -76,3 +76,5 @@ class DockerEvents:
                 await self.task
             except asyncio.CancelledError:
                 pass
+            finally:
+                self.task = None

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -8,7 +8,7 @@ def test_events_default_task(docker):
     docker.events.subscribe()
     assert docker.events.task is not None
     loop.run_until_complete(docker.close())
-    assert docker.events.task.done()
+    assert docker.events.task is None
     assert docker.events.json_stream is None
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -378,6 +378,10 @@ async def test_port(docker, image_name):
 
 @pytest.mark.asyncio
 async def test_events(docker, image_name, event_loop):
+    # Сheck the stop procedure
+    docker.events.subscribe()
+    await docker.events.stop()
+
     subscriber = docker.events.subscribe()
 
     # Do some stuffs to generate events.


### PR DESCRIPTION
## What do these changes do?

DockerEvents objects can be opened but it cannot be reopened again.
That happens due to ```task``` attribute in the ```DockerEvent``` object is never cleared.

The patch changes the ```stop``` procedure making it to clean the ```task``` and changes tests accordingly.

## Are there changes in behavior for the user?

I don't think so, there are minor changes.

## Related issue number

https://github.com/aio-libs/aiodocker/issues/447

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
