### PR TITLE
Fix params passing in Docker API calls

### DIFF
--- a/CHANGES/543.bugfix
+++ b/CHANGES/543.bugfix
@@ -1,0 +1,1 @@
+Fix passing of JSON params.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -22,3 +22,4 @@ Paul Tagliamonte
 Tianon Gravi
 Tommy Beadle
 Travis DePrato
+Yannick Perrenet

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -131,7 +131,7 @@ def httpize(d: Optional[Mapping]) -> Optional[Mapping[str, Any]]:
         if isinstance(v, bool):
             v = "1" if v else "0"
         if not isinstance(v, str):
-            v = str(v)
+            v = json.dumps(v)
         converted[k] = v
     return converted
 


### PR DESCRIPTION
Fixes passing JSON structures as params.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Fixes calls like:
```python
client.containers.list(filters={"network": [network]})
```
where the kwarg passed to `containers.list` (and other functions that query the Docker engine) is a JSON structure (for reference see the [Docker engine API](https://docs.docker.com/engine/api/v1.41/#operation/ContainerList)).

## Are there changes in behavior for the user?

Users can now pass JSON-like params.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
