### PR TITLE
Fix error when Stream is closed after container stopped

### DIFF
--- a/CHANGES/608.bugfix
+++ b/CHANGES/608.bugfix
@@ -1,0 +1,1 @@
+Fix an error when attach/exec when container stops before close connection to it.

--- a/aiodocker/stream.py
+++ b/aiodocker/stream.py
@@ -115,7 +115,7 @@ class Stream:
             return
         self._closed = True
         transport = self._resp.connection.transport
-        if transport.can_write_eof():
+        if transport and transport.can_write_eof():
             transport.write_eof()
         self._resp.close()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -229,6 +229,30 @@ async def test_attach_nontty(docker, image_name, make_container, stderr):
 
 
 @pytest.mark.asyncio
+async def test_attach_nontty_wait_for_exit(docker, image_name, make_container):
+    cmd = ["python", "-c", "import time; time.sleep(3); print('Hello')"]
+
+    config = {
+        "Cmd": cmd,
+        "Image": image_name,
+        "AttachStdin": False,
+        "AttachStdout": False,
+        "AttachStderr": False,
+        "Tty": False,
+        "OpenStdin": False,
+        "StdinOnce": False,
+    }
+
+    container = await make_container(
+        config,
+        name="aiodocker-testing-attach-nontty-wait-for-exit",
+    )
+
+    async with container.attach(stdin=False, stdout=True, stderr=True):
+        await asyncio.sleep(10)
+
+
+@pytest.mark.asyncio
 async def test_attach_tty(docker, image_name, make_container):
     skip_windows()
     config = {


### PR DESCRIPTION
Follow up to https://github.com/aio-libs/aiodocker/pull/605 -- there was an issue when `connector` of an `ClientResponse` is closed before we close the response object. 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
