### PR TITLE
Fix type annotations for Docker labels

### DIFF
--- a/CHANGES/621.misc
+++ b/CHANGES/621.misc
@@ -1,0 +1,1 @@
+Fix type annotations for Docker labels.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -23,4 +23,5 @@ Paul Tagliamonte
 Tianon Gravi
 Tommy Beadle
 Travis DePrato
+Vivien Maisonneuve
 Yannick Perrenet

--- a/aiodocker/configs.py
+++ b/aiodocker/configs.py
@@ -1,6 +1,6 @@
 import json
 from base64 import b64encode
-from typing import Any, List, Mapping
+from typing import Any, List, Mapping, Optional
 
 from .utils import clean_filters, clean_map
 
@@ -33,7 +33,7 @@ class DockerConfigs(object):
         data: str,
         *,
         b64: bool = False,
-        labels: List = None,
+        labels: Optional[Mapping[str, str]] = None,
         templating: Mapping = None,
     ) -> Mapping[str, Any]:
         """
@@ -108,7 +108,7 @@ class DockerConfigs(object):
         name: str = None,
         data: str = None,
         b64: bool = False,
-        labels: List = None,
+        labels: Optional[Mapping[str, str]] = None,
         templating: Mapping = None,
     ) -> bool:
         """

--- a/aiodocker/secrets.py
+++ b/aiodocker/secrets.py
@@ -1,6 +1,6 @@
 import json
 from base64 import b64encode
-from typing import Any, List, Mapping
+from typing import Any, List, Mapping, Optional
 
 from .utils import clean_filters, clean_map
 
@@ -33,7 +33,7 @@ class DockerSecrets(object):
         data: str,
         *,
         b64: bool = False,
-        labels: List = None,
+        labels: Optional[Mapping[str, str]] = None,
         driver: Mapping = None,
         templating: Mapping = None,
     ) -> Mapping[str, Any]:
@@ -111,7 +111,7 @@ class DockerSecrets(object):
         name: str = None,
         data: str = None,
         b64: bool = False,
-        labels: List = None,
+        labels: Optional[Mapping[str, str]] = None,
         driver: Mapping = None,
         templating: Mapping = None,
     ) -> bool:

--- a/aiodocker/services.py
+++ b/aiodocker/services.py
@@ -41,7 +41,7 @@ class DockerServices(object):
         task_template: Mapping[str, Any],
         *,
         name: str = None,
-        labels: List = None,
+        labels: Optional[Mapping[str, str]] = None,
         mode: Mapping = None,
         update_config: Mapping = None,
         rollback_config: Mapping = None,


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This commit fixes invalid type hints for Docker labels: the Docker engine API expects a string-to-string mapping, not a list. See for instance https://docs.docker.com/engine/api/v1.41/#operation/ServiceCreate.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

Labels require dicts, but Mypy expects lists, so users need to introduce `# type: ignore` hints when using labels in typechecked code. If this PR gets accepted, theses hints will become spurious and, depending on Mypy settings, users may have to remove them for typechecking to succeed.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (*note: tests use correct types already*)
- [ ] Documentation reflects the changes (*note: unrelevant*)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
