### PR TITLE
Revert "Bump docutils from 0.17.1 to 0.18 (#634)"

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,5 +1,5 @@
 codecov==2.1.12
-docutils==0.18
+docutils==0.17.1
 tox==3.24.4
 tox-travis==0.12
 pygments==2.10.0


### PR DESCRIPTION
This reverts commit 5a9467c92fe51b6da37260ff288d214e731d3dcf.

sphinx==4.2.0 requires docutils<0.18,>=0.14
