### PR TITLE
fix: remove outdated codes that use 'AsyncCM' interface

### DIFF
--- a/CHANGES/874.fix
+++ b/CHANGES/874.fix
@@ -1,0 +1,1 @@
+Fix a missing removal of the legacy `AsyncCM` interface usage and update type annotations to avoid this in the future

--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -200,7 +200,6 @@ class DockerContainer:
         try:
             inspect_info = await self.show()
         except DockerError:
-            cm.cancel()
             raise
         is_tty = inspect_info["Config"]["Tty"]
 


### PR DESCRIPTION
follow up #861 #850

`_AsynCM` interface has a docker query coroutine as an attribute and #861 allowed the coroutine to be closed.
#850 removed the `_AsynCM` interface but there is still remaining codes that try to call the method of the interface.
Let's remove it.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->


## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
