### PR TITLE
Bump pre-commit hook versions to follow the dependabot updates

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,7 +14,7 @@ on:
 
 
 env:
-  PYTHON_LATEST: 3.12
+  PYTHON_LATEST: '3.12'
   PROJECT_NAME: aiodocker
 
   # For re-actors/checkout-python-sdist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
   autoupdate_schedule: quarterly
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: check-yaml
   - id: end-of-file-fixer
@@ -20,12 +20,12 @@ repos:
   - id: detect-private-key
     exclude: ^tests/certs/
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.3
+  rev: v0.5.0
   hooks:
   - id: ruff
     args: ['--fix']
   - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.10.0
+  rev: v1.10.1
   hooks:
   - id: mypy


### PR DESCRIPTION
This is a follow-up update to dependabot updates.
