### PR TITLE
Do not use the default timeout when streming logs

### DIFF
--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -19,7 +19,7 @@ from typing import (
     overload,
 )
 
-from aiohttp import ClientResponse, ClientWebSocketResponse
+from aiohttp import ClientResponse, ClientWebSocketResponse, ClientTimeout
 from multidict import MultiDict
 from yarl import URL
 
@@ -189,8 +189,11 @@ class DockerContainer:
 
         params = {"stdout": stdout, "stderr": stderr, "follow": follow}
         params.update(kwargs)
+
+        timeout = ClientTimeout(total=None, connect=30, sock_connect=30, sock_read=None)
+
         cm = self.docker._query(
-            f"containers/{self._id}/logs", method="GET", params=params
+            f"containers/{self._id}/logs", method="GET", params=params, timeout=timeout
         )
         if follow:
             return self._logs_stream(cm)


### PR DESCRIPTION
## What do these changes do?

This update modifies the default session timeout in the `aiohttp` client when calling `DockerContainer.log()`. Currently, the default timeout appears to be 300 seconds. By explicitly setting a `ClientTimeout` with `sock_read=None`, the logs can continue streaming as long as the connection remains active. This seems like a more suitable default behavior for continuous log streaming.

## Are there changes in behavior for the user?

There may be a small impact for users who have implemented workarounds to handle the current 5-minute timeout, as they might expect the connection to terminate after that period. However, the overall effect should be minimal.

For better backward compatibility, an alternative approach could be to introduce a `timeout_seconds` parameter in the `DockerContainer.log()` function, defaulting to 300 seconds.

## Related issue number

This issue was originally discussed in #901, and the solution was proposed by @toerb. I have adapted this approach and successfully tested it in my own projects.


## Checklist

- [x] I think the code is well written
- I’m not sure how to unit test or classify this change, as it’s neither a bug fix nor a new feature - just a default setting that seems more appropriate for this use case.