### PR TITLE
fix: Use URL-safe base64 encoding for auth

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -24,6 +24,7 @@ Konstantin Valetov
 Martin Koppehel
 Nikolay Novik
 Paul Tagliamonte
+Robin Tweedie
 Sanghun Lee
 Tianon Gravi
 Tommy Beadle

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -298,4 +298,4 @@ def compose_auth_header(
         auth_json = json.dumps(config).encode("utf-8")
     else:
         raise TypeError("auth must be base64 encoded string/bytes or a dictionary")
-    return base64.b64encode(auth_json).decode("ascii")
+    return base64.urlsafe_b64encode(auth_json).decode("ascii")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,3 +68,8 @@ def test_clean_filters() -> None:
 
     with pytest.raises(TypeError):
         assert utils.clean_filters(filters=())
+
+
+def test_compose_auth_header():
+    auth = {"username": "alice", "password": "~"}
+    assert utils.compose_auth_header(auth) == "eyJ1c2VybmFtZSI6ICJhbGljZSIsICJwYXNzd29yZCI6ICJ-In0="


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Changes `utils.compose_auth_header` to use `base64.urlsafe_b64encode` on the returned string. This aligns with [how the Docker CLI encodes the same header](https://github.com/docker/cli/blob/693ae6ca733193818020823129511f6be14eaae7/cli/command/registry.go#L30-L37).

I discovered this when an application using `aiodocker` was the only client not authenticating successfully against a private registry after a service user's password was rotated.

## Are there changes in behavior for the user?

Will allow authentication to succeed against private registries when the `X-Registry-Auth` require url-safe substitutions as decribed here: https://docs.python.org/3/library/base64.html#base64.urlsafe_b64encode

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
