### PR TITLE
docs: Fix ReadTheDocs build by adding configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/aiodocker/exceptions.py
+++ b/aiodocker/exceptions.py
@@ -13,8 +13,6 @@ class DockerError(Exception):
         message: The error message.
     """
 
-    status: int
-
     def __init__(self, status: int, message: str, *args: Any) -> None:
         super().__init__(message, *args)
         self.status = status

--- a/docs/ssh.rst
+++ b/docs/ssh.rst
@@ -291,12 +291,11 @@ Requirements
 * Docker CLI (``docker`` command) available on the remote host (required for ``docker system dial-stdio``)
 * Docker daemon running and accessible on the remote host
 
-----------
 Reference
-----------
+=========
 
 SSHConnector
-============
+------------
 
 .. autoclass:: aiodocker.ssh.SSHConnector
         :members:


### PR DESCRIPTION
## Summary

- Add `.readthedocs.yaml` configuration file to properly build documentation on ReadTheDocs
- Fix RST title level inconsistency in `docs/ssh.rst` that caused Sphinx warnings
- Remove redundant class annotation in `exceptions.py` that caused duplicate documentation warnings

The documentation at https://aiodocker.readthedocs.io/ has been stuck at version 0.21.0 (from January 2022) because there was no `.readthedocs.yaml` configuration file. Without this file, ReadTheDocs uses legacy defaults that don't properly install the package with its documentation dependencies.

## Test plan

- [x] Verified `uv run sphinx-build -W -E docs docs/_build/html` builds successfully with no warnings
- [x] Verified `uv run mypy aiodocker/exceptions.py` passes