### PR TITLE
feat: add support for images/prune API

### DIFF
--- a/CHANGES/1001.feature
+++ b/CHANGES/1001.feature
@@ -1,1 +1,0 @@
-Add support for the images/prune API to the library.

--- a/CHANGES/1001.feature
+++ b/CHANGES/1001.feature
@@ -1,0 +1,1 @@
+Add support for the images/prune API to the library.

--- a/CHANGES/1001.feature.md
+++ b/CHANGES/1001.feature.md
@@ -1,1 +1,1 @@
-Add support for the `images/prune` API to the library.
+Introduce support in the library for the `images/prune` API endpoint.

--- a/CHANGES/1001.feature.md
+++ b/CHANGES/1001.feature.md
@@ -1,0 +1,1 @@
+Add support for the `images/prune` API to the library.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -25,6 +25,7 @@ Julien Simbola
 Junya Fukuda
 Konstantin Valetov
 Martin Koppehel
+Mike Degatano
 Nikolay Novik
 Paul Tagliamonte
 Robin Tweedie

--- a/aiodocker/images.py
+++ b/aiodocker/images.py
@@ -20,7 +20,7 @@ import aiohttp
 
 from .jsonstream import json_stream_list, json_stream_stream
 from .types import SENTINEL, JSONObject, Sentinel, SupportsRead
-from .utils import clean_map, compose_auth_header
+from .utils import clean_filters, clean_map, compose_auth_header
 
 
 if TYPE_CHECKING:
@@ -254,6 +254,32 @@ class DockerImages:
         response = await self.docker._query_json(
             f"images/{name}", "DELETE", params=params
         )
+        return response
+
+    async def prune(
+        self,
+        *,
+        filters: Optional[Mapping[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Delete unused images
+
+        Args:
+            filters: Filter expressions to limit which images are pruned.
+                    Available filters:
+                    - dangling: When set to "true" (or "1"), prune only unused images that are not tagged.
+                               When set to "false" (or "0"), prune all unused images.
+                    - until: Only remove images created before given timestamp
+                    - label: Only remove images with (or without, if label=<key> is used) the specified labels
+
+        Returns:
+            Dictionary containing information about deleted images and space reclaimed
+        """
+        params = {}
+        if filters is not None:
+            params["filters"] = clean_filters(filters)
+
+        response = await self.docker._query_json("images/prune", "POST", params=params)
         return response
 
     @staticmethod

--- a/aiodocker/images.py
+++ b/aiodocker/images.py
@@ -270,7 +270,7 @@ class DockerImages:
                     - dangling: When set to "true" (or "1"), prune only unused images that are not tagged.
                                When set to "false" (or "0"), prune all unused images.
                     - until: Only remove images created before given timestamp
-                    - label: Only remove images with (or without, if label=<key> is used) the specified labels
+                    - label: Only remove images with (or without, if label!=<key> is used) the specified labels
 
         Returns:
             Dictionary containing information about deleted images and space reclaimed

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -397,5 +397,5 @@ async def test_prune_images_without_filters(docker: Docker) -> None:
     assert isinstance(result, dict)
     assert "ImagesDeleted" in result
     assert "SpaceReclaimed" in result
-    assert result["ImagesDeleted"] is None or isinstance(result["ImagesDeleted"], list)
+    assert result["ImagesDeleted"] is None
     assert isinstance(result["SpaceReclaimed"], int)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -360,3 +360,42 @@ async def test_pull_image_invalid_platform(docker: Docker, image_name: str) -> N
         "unknown operating system or architecture: invalid argument"
         in excinfo.exconly()
     )
+
+
+@pytest.mark.asyncio
+async def test_prune_images(docker: Docker, random_name: str, image_name: str) -> None:
+    # Build an image to create a dangling image
+    name = f"{random_name}:latest"
+    dockerfile = f"""
+    FROM {image_name}
+    """
+    f = BytesIO(dockerfile.encode("utf-8"))
+    tar_obj = utils.mktar_from_dockerfile(f)
+    await docker.images.build(fileobj=tar_obj, encoding="gzip", tag=name)
+    tar_obj.close()
+
+    # Remove the tag to create a dangling image
+    await docker.images.delete(name=name)
+
+    # Prune dangling images
+    result = await docker.images.prune(filters={"dangling": ["true"]})
+
+    # Verify the response structure
+    assert isinstance(result, dict)
+    assert "ImagesDeleted" in result
+    assert "SpaceReclaimed" in result
+    assert isinstance(result["ImagesDeleted"], list)
+    assert isinstance(result["SpaceReclaimed"], int)
+
+
+@pytest.mark.asyncio
+async def test_prune_images_without_filters(docker: Docker) -> None:
+    # Prune without filters
+    result = await docker.images.prune()
+
+    # Verify the response structure
+    assert isinstance(result, dict)
+    assert "ImagesDeleted" in result
+    assert "SpaceReclaimed" in result
+    assert result["ImagesDeleted"] is None or isinstance(result["ImagesDeleted"], list)
+    assert isinstance(result["SpaceReclaimed"], int)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Add support for the `images/prune` API to the library as detailed here: https://docs.docker.com/reference/api/engine/version/v1.53/#tag/Image/operation/ImagePrune

## Are there changes in behavior for the user?

New method for a new API, no changes to existing functionality.

## Related issue number

Not exactly. #691 is kind of related and was also on my list to make a PR for after images though, assume this one was accepted.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
