### PR TITLE
feat: add support for containers/prune API

### DIFF
--- a/CHANGES/1002.feature.md
+++ b/CHANGES/1002.feature.md
@@ -1,0 +1,1 @@
+Introduce support in the library for the `containers/prune` API endpoint.

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -492,11 +492,9 @@ async def test_prune_containers(
 
 
 @pytest.mark.asyncio
-async def test_prune_containers_nothing_to_remove(
-    docker: Docker, random_name: str
-) -> None:
+async def test_prune_containers_nothing_to_remove(docker: Docker) -> None:
     """Test a container prune with nothing to remove."""
-    result = await docker.containers.prune(filters={"label": f"label={random_name}"})
+    result = await docker.containers.prune()
 
     # Verify the response structure
     assert isinstance(result, dict)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -491,10 +491,11 @@ async def test_prune_containers(
 
 
 @pytest.mark.asyncio
-async def test_prune_images_without_filters(docker: Docker) -> None:
-    """Test a container prune with no filters and nothing to remove."""
-    # Prune without filters
-    result = await docker.containers.prune()
+async def test_prune_containers_nothing_to_remove(
+    docker: Docker, random_name: str
+) -> None:
+    """Test a container prune with nothing to remove."""
+    result = await docker.containers.prune(filters={"label": f"label={random_name}"})
 
     # Verify the response structure
     assert isinstance(result, dict)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -461,16 +461,17 @@ async def test_prune_containers(
     """Test that prune with filters removes only the stopped container that matches the filter."""
     # Create two stopped containers
     container_without_label: DockerContainer = await docker.containers.create(
-        {"Image": image_name}, name=random_name
+        {"Image": image_name}, name=f"{random_name}_no_label"
     )
     container_with_label: DockerContainer | None = None
     try:
         container_with_label = await docker.containers.create(
-            {"Image": image_name, "Labels": {"test": ""}}, name=random_name
+            {"Image": image_name, "Labels": {"test": ""}},
+            name=f"{random_name}_with_label",
         )
 
         # Prune stopped containers with label "test"
-        result = await docker.containers.prune(filters={"label": "label=test"})
+        result = await docker.containers.prune(filters={"label": "test"})
 
         # Verify the response structure
         assert isinstance(result, dict)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Add support for the `containers/prune` API as detailed here: https://docs.docker.com/reference/api/engine/version/v1.53/#tag/Container/operation/ContainerPrune

Note: I'm not currently in contributors but since I added myself as part of #1001 I figured I wouldn't add myself again here.

## Are there changes in behavior for the user?

New method for a new API, no changes to existing functionality.

## Related issue number

No but as with #1001, #691 feels somewhat related as its listing prune APIs missing from the library

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
