### PR TITLE
Fix entrypoint usage in broken container tests to unblock CI

### DIFF
--- a/CHANGES/1004.bugfix
+++ b/CHANGES/1004.bugfix
@@ -1,0 +1,1 @@
+Fix entrypoint usage in broken container tests to unblock CI.

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -30,7 +30,7 @@ async def test_run_existing_container(docker: Docker, image_name: str) -> None:
     container = await docker.containers.run(
         config={
             "Cmd": ["-c", "print('hello')"],
-            "Entrypoint": "python",
+            "Entrypoint": ["python"],
             "Image": image_name,
         }
     )
@@ -56,7 +56,7 @@ async def test_run_container_with_missing_image(
     container = await docker.containers.run(
         config={
             "Cmd": ["-c", "print('hello')"],
-            "Entrypoint": "python",
+            "Entrypoint": ["python"],
             "Image": image_name,
         }
     )
@@ -125,7 +125,7 @@ async def test_container_stats_list(docker: Docker, image_name: str) -> None:
     container = await docker.containers.run(
         config={
             "Cmd": ["-c", "print('hello')"],
-            "Entrypoint": "python",
+            "Entrypoint": ["python"],
             "Image": image_name,
         }
     )
@@ -145,7 +145,7 @@ async def test_container_stats_stream(docker: Docker, image_name: str) -> None:
     container = await docker.containers.run(
         config={
             "Cmd": ["-c", "print('hello')"],
-            "Entrypoint": "python",
+            "Entrypoint": ["python"],
             "Image": image_name,
         }
     )


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Fixes #1004 

Confirmed with initial no change commit the tests are broken on main. Appears `entrypoint` must be `list[str]` now in container config, adjusted tests accordingly.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
