### PR TITLE
Release v0.26.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,25 @@ Changes
 
 .. towncrier release notes start
 
+0.26.0 (2026-02-17)
+===================
+
+New Features
+------------
+
+- Introduce support in the library for the `networks/prune` API endpoint. (#691)
+- Introduce support in the library for the `images/prune` API endpoint. (#1001)
+- Introduce support in the library for the `containers/prune` API endpoint. (#1002)
+- Introduce support in the library for the `volumes/prune` API endpoint. (#1003)
+- Introduce support in the library for the `build/prune` API endpoint. (#1007)
+
+
+Miscellaneous
+-------------
+
+- Fix entrypoint usage in broken container tests to unblock CI. (#1004)
+
+
 0.25.0 (2025-12-20)
 ===================
 

--- a/CHANGES/1001.feature.md
+++ b/CHANGES/1001.feature.md
@@ -1,1 +1,0 @@
-Introduce support in the library for the `images/prune` API endpoint.

--- a/CHANGES/1002.feature.md
+++ b/CHANGES/1002.feature.md
@@ -1,1 +1,0 @@
-Introduce support in the library for the `containers/prune` API endpoint.

--- a/CHANGES/1003.feature.md
+++ b/CHANGES/1003.feature.md
@@ -1,1 +1,0 @@
-Introduce support in the library for the `volumes/prune` API endpoint.

--- a/CHANGES/1004.bugfix
+++ b/CHANGES/1004.bugfix
@@ -1,1 +1,0 @@
-Fix entrypoint usage in broken container tests to unblock CI.

--- a/CHANGES/1007.feature.md
+++ b/CHANGES/1007.feature.md
@@ -1,1 +1,0 @@
-Introduce support in the library for the `build/prune` API endpoint.

--- a/CHANGES/691.feature.md
+++ b/CHANGES/691.feature.md
@@ -1,1 +1,0 @@
-Introduce support in the library for the `networks/prune` API endpoint.

--- a/CHANGES/988.fix.md
+++ b/CHANGES/988.fix.md
@@ -1,1 +1,0 @@
-Add explicit `context` argument to the `Docker` instance constructor with explicit documentation for the arg/env/config precedence.

--- a/CHANGES/990.fix
+++ b/CHANGES/990.fix
@@ -1,1 +1,0 @@
-Add timeout parameter to long-running operations (build, import_image, export_image, log, attach, stats) with infinite timeout defaults, and fix timeout handling to set both total and sock_read consistently.


### PR DESCRIPTION
## Summary

- Update `CHANGES.rst` with the 0.26.0 release notes via towncrier
- Remove consumed changelog fragments
- Remove orphaned fragments (`988.fix.md`, `990.fix`) that were already shipped in v0.25.0 but never consumed due to incorrect type naming

## Release notes

### New Features
- Introduce support for the `images/prune` API endpoint (#1001)
- Introduce support for the `containers/prune` API endpoint (#1002)
- Introduce support for the `volumes/prune` API endpoint (#1003)
- Introduce support for the `networks/prune` API endpoint (#691)
- Introduce support for the `build/prune` API endpoint (#1007)

### Miscellaneous
- Fix entrypoint usage in broken container tests to unblock CI (#1004)

## After merge
Tag `v0.26.0` on the merge commit and push the tag to trigger the PyPI publish workflow.