### PR TITLE
Sync on log stream instead of fixed sleep in _validate_hello

### DIFF
--- a/CHANGES/1020.misc
+++ b/CHANGES/1020.misc
@@ -1,0 +1,1 @@
+Replace a fixed five second sleep in the container log test helper with a follow stream read, so the helper waits only as long as the daemon takes to flush log output.

--- a/CHANGES/1020.misc
+++ b/CHANGES/1020.misc
@@ -1,1 +1,1 @@
-Replace a fixed five second sleep in the container log test helper with a follow stream read, so the helper waits only as long as the daemon takes to flush log output.
+Replace a fixed five second sleep in the container log test helper with a follow stream read, so the helper waits only as long as the daemon takes to flush log output -- by :user:`bdraco`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -16,6 +16,7 @@ Gyubong Lee
 Harry Lees
 Hiroki Kiyohara
 Igor Alexandrov
+J. Nick Koston
 Jason Kraus
 Jonathan Carroll Otsuka
 Joongi Kim

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -15,8 +15,10 @@ async def _validate_hello(container: DockerContainer) -> None:
         await container.start()
         response = await container.wait()
         assert response["StatusCode"] == 0
-        await asyncio.sleep(5)  # wait for output in case of slow test container
-        logs = await container.log(stdout=True)
+        # Stream with follow=True so the daemon flushes all output before EOF;
+        # the container has already exited so this returns as soon as the log
+        # buffer drains rather than blocking on a fixed sleep.
+        logs = [line async for line in container.log(stdout=True, follow=True)]
         assert "hello\n" in logs
 
         with pytest.raises(TypeError):


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

The container log test helper waited a fixed five seconds after the container exited, hoping the daemon had flushed all stdout. Now it streams the log with follow=True and collects to EOF, so it returns as soon as the buffer drains.

Locally, test_run_existing_container call time dropped from about 5.5s to about 2.7s, and the same speedup applies to every other test that goes through _validate_hello.

## Are there changes in behavior for the user?

No, this only touches the test suite.

## Related issue number

Part of #1020.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."