### PR TITLE
Wait for container exit instead of fixed sleep in attach nontty test

### DIFF
--- a/CHANGES/1023.misc
+++ b/CHANGES/1023.misc
@@ -1,0 +1,1 @@
+Replace a fixed ten second sleep in the non-TTY attach exit test with a wait for container exit, so the test returns as soon as the container actually finishes -- by :user:`bdraco`.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -282,7 +282,9 @@ async def test_attach_nontty_wait_for_exit(
     )
 
     async with container.attach(stdin=False, stdout=True, stderr=True):
-        await asyncio.sleep(10)
+        # Wait for the container to actually exit instead of sleeping for a
+        # fixed worst-case duration.
+        await container.wait()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

test_attach_nontty_wait_for_exit sleeps a fixed ten seconds while the container runs time.sleep(3) and prints. Switch to awaiting container.wait() so the test returns as soon as the container exits.

## Are there changes in behavior for the user?

No, this only touches the test suite.

## Related issue number

Part of #1020.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."