### PR TITLE
Warn when HostConfig-only fields are placed at the top level of container create config

### DIFF
--- a/CHANGES/735.feature.md
+++ b/CHANGES/735.feature.md
@@ -1,0 +1,1 @@
+Warn via :py:class:`UserWarning` when ``DockerContainers.create()`` receives well-known ``HostConfig``-only fields (such as ``Runtime``, ``Privileged``, ``Binds``, ``NetworkMode``) at the top level of the config, since the Docker daemon silently drops them there.

--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import shlex
 import tarfile
+import warnings
 from contextlib import AbstractAsyncContextManager
 from typing import (
     TYPE_CHECKING,
@@ -35,6 +36,47 @@ from .utils import clean_filters, identical, parse_result
 
 if TYPE_CHECKING:
     from .docker import Docker
+
+
+# Subset of fields that live under ``HostConfig`` in the Docker Engine
+# ``/containers/create`` API. When a caller places one of these at the top
+# level of the config dict, the Docker daemon silently drops it. We warn so
+# users do not lose hours debugging "why didn't my Runtime/Privileged stick?".
+_HOST_CONFIG_ONLY_FIELDS = frozenset({
+    "AutoRemove",
+    "Binds",
+    "CapAdd",
+    "CapDrop",
+    "Devices",
+    "ExtraHosts",
+    "IpcMode",
+    "Mounts",
+    "NetworkMode",
+    "PidMode",
+    "PortBindings",
+    "Privileged",
+    "PublishAllPorts",
+    "ReadonlyRootfs",
+    "RestartPolicy",
+    "Runtime",
+    "SecurityOpt",
+    "Tmpfs",
+    "VolumesFrom",
+})
+
+
+def _warn_misplaced_host_config_fields(config: Any) -> None:
+    if not isinstance(config, Mapping):
+        return
+    for field in config:
+        if field in _HOST_CONFIG_ONLY_FIELDS:
+            warnings.warn(
+                f"{field!r} is a HostConfig field but was placed at the top "
+                f"level of the container config; Docker will ignore it. "
+                f"Move it to config['HostConfig'][{field!r}].",
+                UserWarning,
+                stacklevel=3,
+            )
 
 
 class DockerContainers:
@@ -76,6 +118,7 @@ class DockerContainers:
         *,
         name: Optional[str] = None,
     ) -> DockerContainer:
+        _warn_misplaced_host_config_fields(config)
         url = "containers/create"
         encoded_config = json.dumps(config, sort_keys=True).encode("utf-8")
         kwargs = {}

--- a/docs/containers.rst
+++ b/docs/containers.rst
@@ -38,3 +38,15 @@ Create a container
 
     if __name__ == "__main__":
         asyncio.run(create_container())
+
+.. note::
+
+   Some commonly-used fields — including ``Runtime``, ``Privileged``,
+   ``Binds``, ``NetworkMode``, ``RestartPolicy``, and ``PortBindings`` —
+   belong **inside** ``HostConfig``, not at the top level of the config
+   dict. Docker silently ignores them when placed at the top level. See the
+   `Docker Engine API reference
+   <https://docs.docker.com/engine/api/latest/#tag/Container/operation/ContainerCreate>`_
+   for the authoritative field list. ``aiodocker`` emits a
+   :py:class:`UserWarning` when it detects a well-known ``HostConfig``-only
+   field at the top level.

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,11 +1,15 @@
 import asyncio
 import secrets
 import sys
+import warnings
 from contextlib import suppress
 
 import pytest
 
-from aiodocker.containers import DockerContainer
+from aiodocker.containers import (
+    DockerContainer,
+    _warn_misplaced_host_config_fields,
+)
 from aiodocker.docker import Docker
 from aiodocker.exceptions import DockerContainerError, DockerError
 
@@ -544,3 +548,44 @@ def test_container_contains() -> None:
     assert "Id" in container
     assert "State" in container
     assert "Missing" not in container
+
+
+def test_warn_misplaced_host_config_field_runtime() -> None:
+    """`Runtime` at top level should trigger a UserWarning pointing at HostConfig."""
+    config = {
+        "Image": "alpine:latest",
+        "Runtime": "runc",
+    }
+    with pytest.warns(UserWarning, match="HostConfig") as record:
+        _warn_misplaced_host_config_fields(config)
+    assert any("Runtime" in str(w.message) for w in record)
+
+
+def test_warn_misplaced_host_config_field_nested_is_silent() -> None:
+    """No warning should fire when the field is correctly inside HostConfig."""
+    config = {
+        "Image": "alpine:latest",
+        "HostConfig": {"Runtime": "runc"},
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _warn_misplaced_host_config_fields(config)
+    assert not [w for w in caught if "HostConfig" in str(w.message)]
+
+
+@pytest.mark.asyncio
+async def test_create_with_runtime_in_host_config(
+    docker: Docker, image_name: str
+) -> None:
+    """Setting Runtime via HostConfig must survive a create + inspect round-trip."""
+    container = await docker.containers.create(
+        config={
+            "Image": image_name,
+            "HostConfig": {"Runtime": "runc"},
+        }
+    )
+    try:
+        info = await container.show()
+        assert info["HostConfig"]["Runtime"] == "runc"
+    finally:
+        await container.delete(force=True)


### PR DESCRIPTION
Resolves #735

## Summary
Adds a `UserWarning` when callers pass well-known `HostConfig`-only fields (such as `Runtime`, `Privileged`, `Binds`, `NetworkMode`) at the top level of the dict given to `DockerContainers.create()`. Docker silently ignores those fields when they appear at the top level, which is the trap the reporter of #735 hit (their custom `Runtime` was never applied). The warning names the misplaced field and points the user to `config["HostConfig"][<field>]`.

## Implementation Plan

### Approach
Add a small private helper in `aiodocker/containers.py` that walks the top-level keys of the `config` dict passed to `DockerContainers.create()` and emits a `UserWarning` for each known `HostConfig`-only field. No auto-fix, no validation framework, no behavior change beyond emitting a warning.

### Steps
1. **`aiodocker/containers.py`**: Add `import warnings`. Define a module-level frozenset `_HOST_CONFIG_ONLY_FIELDS` listing ~15 commonly-misplaced HostConfig fields. Add private helper `_warn_misplaced_host_config_fields(config)` that emits a `UserWarning` for each top-level key found in that set. Call the helper as the first line of `DockerContainers.create()` so `create()`, `run()`, and `create_or_replace()` all benefit.
2. **`tests/test_containers.py`**: Add a synchronous unit test that exercises the helper directly (warning emitted for misplaced field, no warning when correctly nested in `HostConfig`). Add an integration test that creates a container with `HostConfig.Runtime = "runc"` and asserts the value sticks after `inspect`.
3. **`docs/containers.rst`**: Append a short `.. note::` directive explaining the HostConfig placement gotcha with `Runtime`/`Privileged`/`Binds`/`NetworkMode` as examples.
4. **`CHANGES/735.feature.md`**: Towncrier fragment describing the new warning.

### Files to Modify
- `aiodocker/containers.py` — add helper + call site in `create()`.
- `tests/test_containers.py` — add unit and integration tests.
- `docs/containers.rst` — append placement note.

### Files to Create
- `CHANGES/735.feature.md` — towncrier news fragment.

### Edge Cases
- `config` is not a `Mapping`: defensive `isinstance` check makes the helper a no-op.
- Field set is a strict allowlist (~15 fields), so we never warn about top-level fields Docker does accept.
- `filterwarnings = [\"error\"]` in `pyproject.toml` would promote the new warning to an error in tests — verified no existing test passes any of the listed fields at the top level.
- `Runtime: \"runc\"` is the default Docker runtime, always present, so the integration test does not need to skip per-platform.

### Testing Strategy
- Unit test: call helper directly, assert `UserWarning` with message mentioning both the field name and `HostConfig`; assert no warning when the field is correctly nested.
- Integration test: create a container with `{\"Image\": image_name, \"HostConfig\": {\"Runtime\": \"runc\"}}`, inspect, assert `info[\"HostConfig\"][\"Runtime\"] == \"runc\"`, clean up with `delete(force=True)`.

## Analysis

### Root Cause / Background
The reporter put `\"Runtime\": \"io.containerd.runc.v2\"` at the top level of their container config. Docker's REST API (v1.40+) places `Runtime` inside `HostConfig`; unknown top-level fields are silently dropped by the daemon. aiodocker's `DockerContainers.create()` JSON-encodes the dict as-is and sends it to `/containers/create` without any structural validation, so the misplacement is invisible until the user inspects the resulting container.

### Affected Code Paths
- `aiodocker/containers.py:73-87` — `DockerContainers.create()`: serializes the config dict and posts it to `containers/create`. No validation.
- `aiodocker/docker.py` — `Docker._query_json()`: transport layer, no config-specific handling.
- `aiodocker/utils.py` — no helper for config validation today.

### Existing Tests
- `tests/test_containers.py` — many container-create tests, none exercise `Runtime` or assert HostConfig fields are applied.
- `tests/test_integration.py` — `test_port()` uses HostConfig correctly but does not cover the placement-warning case.

### Dependencies & Impact
- Pure additive change. No public API rename, no behavior change for correctly-placed configs.
- Existing callers that already nest fields in `HostConfig` are unaffected.
- Callers that pass an unknown HostConfig-only field at the top level will start seeing a `UserWarning`; in the test suite this is promoted to an error by `pyproject.toml`'s `filterwarnings = [\"error\"]`. Scan of the test suite confirms no existing call site triggers the new warning.

## Test Plan
- [ ] Unit test: `_warn_misplaced_host_config_fields` emits `UserWarning` for misplaced `Runtime` at top level.
- [ ] Unit test: no warning when `Runtime` is correctly inside `HostConfig`.
- [ ] Integration test: `HostConfig.Runtime = \"runc\"` survives container create + inspect round-trip.
- [ ] Existing test suite (`pytest`) passes without new warnings being promoted to errors.
- [ ] `ruff check` and type-check pass.