### PR TITLE
Use uv for the build and twine-check CI jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -41,9 +41,11 @@ jobs:
         fetch-depth: 0
         filter: 'blob:none'
     - name: Install uv and Python
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ env.PYTHON_LATEST }}
+        activate-environment: true
+        enable-cache: true
     - name: Build artifacts
       run: uv build
     - name: Upload built artifacts for testing
@@ -64,11 +66,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
     - name: Install uv and Python ${{ env.PYTHON_LATEST }}
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ env.PYTHON_LATEST }}
+        activate-environment: true
+        enable-cache: true
     - name: Install dependencies
-      run: uv pip install --system -e '.[lint]'
+      run: uv pip install -e '.[lint]'
     - uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit/
@@ -91,9 +95,11 @@ jobs:
         name: ${{ env.dists-artifact-name }}
         path: dist
     - name: Install uv and Python ${{ env.PYTHON_LATEST }}
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ env.PYTHON_LATEST }}
+        activate-environment: true
+        enable-cache: true
     - name: Run twine checker
       run: uvx twine check --strict dist/*
 
@@ -127,18 +133,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v5
     - name: Install uv and Python ${{ matrix.python-version }}
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.python-version }}
+        activate-environment: true
+        enable-cache: true
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.dists-artifact-name }}
         path: dist
     - name: Install dependencies
-      run: uv pip install --system -e '.[test]' 'aiohttp~=${{ matrix.aiohttp-version }}.0'
+      run: uv pip install -e '.[test]' 'aiohttp~=${{ matrix.aiohttp-version }}.0'
     - name: Install the build artifact
-      run: uv pip install --system dist/aiodocker*.whl
+      run: uv pip install dist/aiodocker*.whl
     # NOTE: Unfortunately the gain of image caching is too small,
     #       and even it increases the latency of Linux jobs. :(
     # - name: Cache Docker images

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,12 +71,11 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_LATEST }}
-    - name: Install uv
-      uses: astral-sh/setup-uv@v8.1.0
-      with:
-        enable-cache: true
+        cache: pip
     - name: Install dependencies
-      run: uv pip install --system -e '.[lint]'
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e '.[lint]'
     - uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit/
@@ -142,19 +141,19 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install uv
-      uses: astral-sh/setup-uv@v8.1.0
-      with:
-        enable-cache: true
+        cache: pip
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.dists-artifact-name }}
         path: dist
     - name: Install dependencies
-      run: uv pip install --system -e '.[test]' 'aiohttp~=${{ matrix.aiohttp-version }}.0'
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e '.[test]' 'aiohttp~=${{ matrix.aiohttp-version }}.0'
     - name: Install the build artifact
-      run: uv pip install --system dist/aiodocker*.whl
+      run: |
+        python -m pip install dist/aiodocker*.whl
     # NOTE: Unfortunately the gain of image caching is too small,
     #       and even it increases the latency of Linux jobs. :(
     # - name: Cache Docker images

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,15 +40,12 @@ jobs:
         # so that dynamic version for build work correctly.
         fetch-depth: 0
         filter: 'blob:none'
-    - name: Set up Python
-      uses: actions/setup-python@v6
+    - name: Install uv and Python
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{ env.PYTHON_LATEST }}
-        cache: pip
-    - name: Install core libraries for build
-      run: python -m pip install build
     - name: Build artifacts
-      run: python -m build
+      run: uv build
     - name: Upload built artifacts for testing
       uses: actions/upload-artifact@v4
       with:
@@ -66,19 +63,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v5
-    - name: Setup Python ${{ env.PYTHON_LATEST }}
-      uses: actions/setup-python@v6
+    - name: Install uv and Python ${{ env.PYTHON_LATEST }}
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{ env.PYTHON_LATEST }}
-        cache: pip
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e '.[lint]'
+      run: uv pip install --system -e '.[lint]'
     - uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit/
-        key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+        key: pre-commit-4|${{ env.PYTHON_LATEST }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - name: Run linters
       run: |
         make lint
@@ -96,15 +90,12 @@ jobs:
       with:
         name: ${{ env.dists-artifact-name }}
         path: dist
-    - name: Setup Python ${{ env.PYTHON_LATEST }}
-      uses: actions/setup-python@v6
+    - name: Install uv and Python ${{ env.PYTHON_LATEST }}
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{ env.PYTHON_LATEST }}
-        cache: pip
     - name: Run twine checker
-      run: |
-        pip install twine
-        twine check --strict dist/*
+      run: uvx twine check --strict dist/*
 
   test:
     name: 'test (Python ${{ matrix.python-version }}, aiohttp ${{ matrix.aiohttp-version }}, ${{ matrix.os }})'
@@ -135,23 +126,19 @@ jobs:
         docker version
     - name: Checkout
       uses: actions/checkout@v5
-    - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+    - name: Install uv and Python ${{ matrix.python-version }}
+      uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{ matrix.python-version }}
-        cache: pip
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
         name: ${{ env.dists-artifact-name }}
         path: dist
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e '.[test]' 'aiohttp~=${{ matrix.aiohttp-version }}.0'
+      run: uv pip install --system -e '.[test]' 'aiohttp~=${{ matrix.aiohttp-version }}.0'
     - name: Install the build artifact
-      run: |
-        python -m pip install dist/aiodocker*.whl
+      run: uv pip install --system dist/aiodocker*.whl
     # NOTE: Unfortunately the gain of image caching is too small,
     #       and even it increases the latency of Linux jobs. :(
     # - name: Cache Docker images

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,11 +40,13 @@ jobs:
         # so that dynamic version for build work correctly.
         fetch-depth: 0
         filter: 'blob:none'
-    - name: Install uv and Python
-      uses: astral-sh/setup-uv@v8.1.0
+    - name: Set up Python
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_LATEST }}
-        activate-environment: true
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.1.0
+      with:
         enable-cache: true
     - name: Build artifacts
       run: uv build
@@ -65,18 +67,20 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v5
-    - name: Install uv and Python ${{ env.PYTHON_LATEST }}
-      uses: astral-sh/setup-uv@v8.1.0
+    - name: Setup Python ${{ env.PYTHON_LATEST }}
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_LATEST }}
-        activate-environment: true
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.1.0
+      with:
         enable-cache: true
     - name: Install dependencies
-      run: uv pip install -e '.[lint]'
+      run: uv pip install --system -e '.[lint]'
     - uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit/
-        key: pre-commit-4|${{ env.PYTHON_LATEST }}|${{ hashFiles('.pre-commit-config.yaml') }}
+        key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - name: Run linters
       run: |
         make lint
@@ -94,11 +98,13 @@ jobs:
       with:
         name: ${{ env.dists-artifact-name }}
         path: dist
-    - name: Install uv and Python ${{ env.PYTHON_LATEST }}
-      uses: astral-sh/setup-uv@v8.1.0
+    - name: Setup Python ${{ env.PYTHON_LATEST }}
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_LATEST }}
-        activate-environment: true
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.1.0
+      with:
         enable-cache: true
     - name: Run twine checker
       run: uvx twine check --strict dist/*
@@ -132,11 +138,13 @@ jobs:
         docker version
     - name: Checkout
       uses: actions/checkout@v5
-    - name: Install uv and Python ${{ matrix.python-version }}
-      uses: astral-sh/setup-uv@v8.1.0
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-        activate-environment: true
+    - name: Install uv
+      uses: astral-sh/setup-uv@v8.1.0
+      with:
         enable-cache: true
     - name: Download all the dists
       uses: actions/download-artifact@v4
@@ -144,9 +152,9 @@ jobs:
         name: ${{ env.dists-artifact-name }}
         path: dist
     - name: Install dependencies
-      run: uv pip install -e '.[test]' 'aiohttp~=${{ matrix.aiohttp-version }}.0'
+      run: uv pip install --system -e '.[test]' 'aiohttp~=${{ matrix.aiohttp-version }}.0'
     - name: Install the build artifact
-      run: uv pip install dist/aiodocker*.whl
+      run: uv pip install --system dist/aiodocker*.whl
     # NOTE: Unfortunately the gain of image caching is too small,
     #       and even it increases the latency of Linux jobs. :(
     # - name: Cache Docker images

--- a/CHANGES/1026.misc
+++ b/CHANGES/1026.misc
@@ -1,0 +1,1 @@
+Switch the CI workflow to install dependencies and build artifacts with uv instead of pip, which speeds up every job that installs Python packages -- by :user:`bdraco`.

--- a/CHANGES/1026.misc
+++ b/CHANGES/1026.misc
@@ -1,1 +1,1 @@
-Switch the CI workflow to install packages with ``uv`` and build artifacts with ``uv build``, while keeping ``actions/setup-python`` for the interpreter -- by :user:`bdraco`.
+Build the distribution with ``uv build`` and run ``twine`` through ``uvx`` in CI, dropping the dedicated ``pip install`` steps for ``build`` and ``twine`` -- by :user:`bdraco`.

--- a/CHANGES/1026.misc
+++ b/CHANGES/1026.misc
@@ -1,1 +1,1 @@
-Switch the CI jobs from ``actions/setup-python`` to ``astral-sh/setup-uv`` for installing the Python interpreter, and from ``pip`` to ``uv`` for installing dependencies and building artifacts -- by :user:`bdraco`.
+Switch the CI workflow to install packages with ``uv`` and build artifacts with ``uv build``, while keeping ``actions/setup-python`` for the interpreter -- by :user:`bdraco`.

--- a/CHANGES/1026.misc
+++ b/CHANGES/1026.misc
@@ -1,1 +1,1 @@
-Switch the CI workflow to install dependencies and build artifacts with uv instead of pip, which speeds up every job that installs Python packages -- by :user:`bdraco`.
+Switch the CI jobs from ``actions/setup-python`` to ``astral-sh/setup-uv`` for installing the Python interpreter, and from ``pip`` to ``uv`` for installing dependencies and building artifacts -- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Replace `python -m build` with `uv build` in the build job, and replace the dedicated `pip install twine` plus `twine check` pair in the twine-check job with a single `uvx twine check` call. Both jobs add `astral-sh/setup-uv@v8.1.0` next to the existing `actions/setup-python` step, and the now-unused `cache: pip` setting is removed from those two jobs.

I tried two broader variants first; both ran into trouble with the Python 3.14 plus aiohttp 3.10 matrix cell. Using `setup-uv` to install Python pulls `python-build-standalone`, which enforces PEP 765 as a `SyntaxError`, and aiohttp 3.10.11 has `break` inside a `finally` block in `web_protocol.py`. Routing `pip install` through `uv pip install --system` on top of hostedtoolcache Python failed in the same import collection step for reasons I have not been able to pin down, while the existing `python -m pip install` flow keeps working. So the test and lint jobs stay on `pip` for now, and uv is limited to the two jobs where the install path is short and the win is clean.

## Are there changes in behavior for the user?

No, this only affects CI runner provisioning.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."