### PR TITLE
Accept typed `filters` mapping in `DockerImages.list()`

### DIFF
--- a/CHANGES/696.feature.md
+++ b/CHANGES/696.feature.md
@@ -1,0 +1,1 @@
+Accept a typed ``filters`` mapping in ``DockerImages.list()`` (e.g. ``{"dangling": ["true"]}``), matching the style of ``volumes.list()``, ``networks.list()``, and ``images.prune()``. A pre-encoded JSON string is still accepted for backwards compatibility, but emits a ``DeprecationWarning`` and will be removed in 1.0.

--- a/aiodocker/images.py
+++ b/aiodocker/images.py
@@ -31,10 +31,37 @@ class DockerImages:
     def __init__(self, docker: Docker) -> None:
         self.docker = docker
 
-    async def list(self, **params) -> List[Any]:
+    async def list(
+        self,
+        *,
+        filters: Optional[Union[Mapping[str, Any], str]] = None,
+        **params,
+    ) -> List[Any]:
         """
         List of images
+
+        Args:
+            filters: Filter expressions for the listing. Accepts a mapping
+                like ``{"dangling": ["true"]}``, ``{"label": ["foo=bar"]}``,
+                or ``{"reference": ["busybox"]}``. A pre-encoded JSON string
+                is also accepted for backwards compatibility, but is
+                deprecated and will be removed in 1.0.
+            **params: Additional query parameters forwarded to
+                ``GET /images/json`` (e.g. ``all``, ``digests``,
+                ``shared_size``).
         """
+        if filters is not None:
+            if isinstance(filters, str):
+                warnings.warn(
+                    "Passing `filters` as a pre-encoded JSON string is "
+                    "deprecated and will be removed in 1.0. Pass a mapping "
+                    "such as {'dangling': ['true']} instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                params["filters"] = filters
+            else:
+                params["filters"] = clean_filters(filters)
         response = await self.docker._query_json("images/json", "GET", params=params)
         return response
 

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -242,14 +242,15 @@ def clean_filters(filters: Optional[Mapping[str, Any] | Sequence[str]] = None) -
     """
     if filters is None:
         return "{}"
-    if isinstance(filters, dict):
+    if isinstance(filters, Mapping):
+        normalized: dict[str, list[Any]] = {}
         for k, v in filters.items():
             if not isinstance(v, list):
                 v = [v]
-            filters[k] = v
+            normalized[k] = v
     else:
         raise TypeError("filters must be a mapping")
-    return json.dumps(filters)
+    return json.dumps(normalized)
 
 
 def mktar_from_dockerfile(fileobj: Union[BytesIO, IO[bytes]]) -> IO[bytes]:

--- a/aiodocker/utils.py
+++ b/aiodocker/utils.py
@@ -6,16 +6,16 @@ import contextvars
 import json
 import tarfile
 import tempfile
+from collections.abc import (
+    Iterable,
+    Mapping,
+    Sequence,
+)
 from io import BytesIO
 from typing import (
     IO,
     Any,
-    Dict,
-    Iterable,
-    Mapping,
     Optional,
-    Sequence,
-    Tuple,
     Union,
     cast,
     overload,
@@ -68,7 +68,7 @@ async def parse_result(response, response_type=None, *, encoding="utf-8"):
     return data
 
 
-def parse_content_type(ct: str) -> Tuple[str, str, Mapping[str, str]]:
+def parse_content_type(ct: str) -> tuple[str, str, Mapping[str, str]]:
     """
     Decompose the value of HTTP "Content-Type" header into
     the main/sub MIME types and other extra options as a dictionary.
@@ -215,7 +215,7 @@ def format_env(key, value: Union[None, bytes, str]) -> str:
 
 def clean_networks(
     networks: Optional[Iterable[str]] = None,
-) -> Optional[Sequence[Dict[str, Any]]]:
+) -> Optional[Sequence[dict[str, Any]]]:
     """
     Cleans the values inside `networks`
     Returns a new list

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -120,6 +120,26 @@ async def test_list_images(docker: Docker, image_name: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_images_with_dangling_filter(docker: Docker) -> None:
+    # The filter should be JSON-encoded and forwarded; whatever the daemon
+    # returns must be a list, and every entry must actually be dangling
+    # (i.e. have no real RepoTags). An empty list is a valid result.
+    dangling = await docker.images.list(filters={"dangling": ["true"]})
+    assert isinstance(dangling, list)
+    for img in dangling:
+        tags = img.get("RepoTags") or []
+        assert tags == [] or tags == ["<none>:<none>"]
+
+
+@pytest.mark.asyncio
+async def test_list_images_filters_str_is_deprecated(
+    docker: Docker, image_name: str
+) -> None:
+    with pytest.warns(DeprecationWarning, match="pre-encoded JSON string"):
+        await docker.images.list(filters='{"reference":["' + image_name + '"]}')
+
+
+@pytest.mark.asyncio
 async def test_tag_image(docker: Docker, random_name: str, image_name: str) -> None:
     repository = random_name
     await docker.images.tag(name=image_name, repo=repository, tag="1.0")

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -120,15 +120,19 @@ async def test_list_images(docker: Docker, image_name: str) -> None:
 
 
 @pytest.mark.asyncio
-async def test_list_images_with_dangling_filter(docker: Docker) -> None:
-    # The filter should be JSON-encoded and forwarded; whatever the daemon
-    # returns must be a list, and every entry must actually be dangling
-    # (i.e. have no real RepoTags). An empty list is a valid result.
-    dangling = await docker.images.list(filters={"dangling": ["true"]})
-    assert isinstance(dangling, list)
-    for img in dangling:
+async def test_list_images_filters_mapping_is_forwarded(
+    docker: Docker, image_name: str
+) -> None:
+    # Scope by `reference` to the known fixture image. If the mapping were
+    # not JSON-encoded and forwarded as `filters`, the daemon would return
+    # every image and the per-tag assertion below would fail on unrelated
+    # entries.
+    matched = await docker.images.list(filters={"reference": [image_name]})
+    assert isinstance(matched, list)
+    assert len(matched) >= 1
+    for img in matched:
         tags = img.get("RepoTags") or []
-        assert tags == [] or tags == ["<none>:<none>"]
+        assert any(t == image_name or t.startswith(f"{image_name}:") for t in tags)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `DockerImages.list()` now takes a typed `filters=` keyword that runs through `clean_filters()`, matching the call shape of `volumes.list()`, `networks.list()`, and the new `images.prune()` (#1001 in 0.26).
- Listing dangling images becomes ergonomic: `await docker.images.list(filters={"dangling": ["true"]})` — no JSON string juggling.
- A pre-encoded JSON string is still accepted to preserve the existing call shape, but emits a `DeprecationWarning` and will be removed in 1.0.

## Context

#696 asked for two things: a way to `docker image purge` and a way to enumerate dangling images. The purge half is fully covered by `images.prune()` shipped in 0.26 (#1001). The listing half technically worked already because `images.list(**params)` blindly forwards anything to `GET /images/json`, but the caller had to JSON-encode the `filters` map themselves — inconsistent with every other `list()`/`prune()` in the library. This change closes that ergonomic gap so #696 can be retired.

Closes #696.

## Test plan
- [x] `tests/test_images.py::test_list_images` — regression: existing `**params` forwarding still works.
- [x] `tests/test_images.py::test_list_images_filters_mapping_is_forwarded` — new: typed mapping is JSON-encoded via `clean_filters()` and respected by the daemon. Uses a `reference` filter scoped to the fixture image so the test is non-mutating (no need to fabricate a dangling image); if the filter weren't forwarded, the daemon would return every image and the per-tag assertion would fail on unrelated entries.
- [x] `tests/test_images.py::test_list_images_filters_str_is_deprecated` — new: pre-encoded JSON string path still works and emits `DeprecationWarning`.