### PR TITLE
docs: Enhance examples from GitHub questions or user mistakes

### DIFF
--- a/CHANGES/614.misc
+++ b/CHANGES/614.misc
@@ -1,0 +1,1 @@
+Document how to bind-mount a host directory via ``HostConfig.Binds`` and ``HostConfig.Mounts``, including bind-propagation options (``shared``, ``slave``, etc.) and the host-side ``mount --make-shared`` prerequisite -- by :user:`achimnol`.

--- a/CHANGES/831.misc
+++ b/CHANGES/831.misc
@@ -1,0 +1,1 @@
+Document ``docker.containers.list(all=True)`` for listing stopped containers, and note that any keyword argument is forwarded as a query parameter to the Docker Engine ``GET /containers/json`` endpoint -- by :user:`achimnol`.

--- a/docs/containers.rst
+++ b/docs/containers.rst
@@ -38,3 +38,87 @@ Create a container
 
     if __name__ == "__main__":
         asyncio.run(create_container())
+
+List containers
+~~~~~~~~~~~~~~~
+
+By default, ``list()`` only returns running containers (equivalent to
+``docker ps``). To include stopped containers (equivalent to ``docker ps -a``),
+pass ``all=True``:
+
+.. code-block:: python
+
+    import asyncio
+    import aiodocker
+
+    async def list_containers():
+        docker = aiodocker.Docker()
+        # Running containers only
+        running = await docker.containers.list()
+        # All containers, including stopped ones
+        all_containers = await docker.containers.list(all=True)
+        for c in all_containers:
+            print(c["Id"], c["State"])
+        await docker.close()
+
+    if __name__ == "__main__":
+        asyncio.run(list_containers())
+
+Any keyword argument is forwarded as a query parameter to the Docker Engine
+``GET /containers/json`` endpoint, so ``filters``, ``limit``, and ``size`` work
+the same way — see the `Docker Engine API reference
+<https://docs.docker.com/reference/api/engine/latest/#tag/Container/operation/ContainerList>`_.
+
+Bind-mount a host directory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``containers.create()`` forwards its ``config`` dict to the Docker Engine
+`POST /containers/create
+<https://docs.docker.com/reference/api/engine/latest/#tag/Container/operation/ContainerCreate>`_
+endpoint, so any ``HostConfig`` field is available. Two ways to bind-mount a
+host path:
+
+**Legacy** — ``HostConfig.Binds`` takes ``"<host>:<container>[:<opts>]"`` strings.
+Options are comma-separated and include ``ro``, ``rw``, ``z``/``Z`` (SELinux
+relabel), and the propagation modes ``shared`` / ``rshared`` / ``slave`` /
+``rslave`` / ``private`` / ``rprivate``:
+
+.. code-block:: python
+
+    config = {
+        "Image": "alpine:latest",
+        "Cmd": ["/bin/ls", "/data"],
+        "HostConfig": {
+            "Binds": ["/host/path:/data:ro,shared"],
+        },
+    }
+
+**Recommended** — ``HostConfig.Mounts`` is a list of structured mount specs.
+Propagation is a named field, which is easier to read and harder to mistype:
+
+.. code-block:: python
+
+    config = {
+        "Image": "alpine:latest",
+        "Cmd": ["/bin/ls", "/data"],
+        "HostConfig": {
+            "Mounts": [
+                {
+                    "Type": "bind",
+                    "Source": "/host/path",
+                    "Target": "/data",
+                    "ReadOnly": True,
+                    "BindOptions": {"Propagation": "shared"},
+                },
+            ],
+        },
+    }
+
+.. note::
+
+   Propagation modes other than ``rprivate`` require the **host-side** mount
+   to already have a compatible propagation type — e.g. ``shared`` only works
+   if ``/host/path`` is itself a shared mount on the host (see
+   ``findmnt -o TARGET,PROPAGATION`` and ``mount --make-shared``). This is a
+   Linux kernel constraint, not an aiodocker limitation; if the host mount is
+   private, Docker will silently downgrade or reject the propagation flag.


### PR DESCRIPTION
## Summary

- Add a **List containers** example showing `docker.containers.list(all=True)` (equivalent to `docker ps -a`), and note that any keyword argument is forwarded as a query parameter to the Docker Engine `GET /containers/json` endpoint.
- Add a **Bind-mount a host directory** example covering both the legacy `HostConfig.Binds` shorthand and the structured `HostConfig.Mounts` form, including bind-propagation options (`shared`, `slave`, etc.) and the host-side `mount --make-shared` prerequisite that's actually the typical blocker when propagation "doesn't work".
- External Docker Engine API links use the unversioned `…/engine/latest/` URL so they don't pin to v1.43.

Resolves #831.
Resolves #614.

## Test plan

- [x] `python -m sphinx -b html docs docs/_build/html` succeeds (the 3 remaining warnings are pre-existing `prune()` docstring issues in `aiodocker/images.py` and `aiodocker/volumes.py`, unrelated to this change).
- [x] Rendered `containers.html` shows the new "List containers" and "Bind-mount a host directory" subsections with working code highlighting and external links.