### PR TITLE
fix: emit ResourceWarning when Stream is leaked with live response

### DIFF
--- a/CHANGES/1033.bugfix.md
+++ b/CHANGES/1033.bugfix.md
@@ -1,0 +1,1 @@
+Fix the inverted condition in ``Stream.__del__`` so a ``ResourceWarning`` is emitted when a stream is garbage-collected while still holding a live, unclosed response.

--- a/aiodocker/stream.py
+++ b/aiodocker/stream.py
@@ -150,7 +150,7 @@ class Stream:
         return None
 
     def __del__(self, _warnings=warnings) -> None:
-        if self._resp is not None:
+        if self._resp is None:
             return
         if not self._closed:
             warnings.warn("Unclosed ExecStream", ResourceWarning)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,48 @@
+"""Tests for ``aiodocker.stream.Stream`` lifecycle warnings."""
+
+import gc
+import warnings
+
+import pytest
+
+from aiodocker.stream import Stream
+
+
+def _make_stream() -> Stream:
+    """Construct a ``Stream`` without touching the network."""
+    stream = Stream.__new__(Stream)
+    stream._setup = None  # type: ignore[assignment]
+    stream.docker = None  # type: ignore[assignment]
+    stream._resp = None
+    stream._closed = False
+    stream._timeout = None
+    stream._queue = None
+    return stream
+
+
+def test_del_warns_when_resp_set_and_not_closed() -> None:
+    stream = _make_stream()
+    stream._resp = object()  # type: ignore[assignment]
+    stream._closed = False
+    with pytest.warns(ResourceWarning, match="Unclosed ExecStream"):
+        del stream
+        gc.collect()
+
+
+def test_del_silent_when_resp_is_none() -> None:
+    stream = _make_stream()
+    assert stream._resp is None
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        del stream
+        gc.collect()
+
+
+def test_del_silent_when_closed() -> None:
+    stream = _make_stream()
+    stream._resp = object()  # type: ignore[assignment]
+    stream._closed = True
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        del stream
+        gc.collect()


### PR DESCRIPTION
## Summary

- The condition in ``Stream.__del__`` was inverted: it returned early when ``self._resp is not None`` (the case where a leak *is* possible) and emitted ``ResourceWarning`` only when ``self._resp is None`` (which can never leak). The fix flips the guard so the warning fires when the stream is GC'd while still holding a live, unclosed response.
- Adds ``tests/test_stream.py`` pinning the three branches of ``__del__``: warns when ``_resp`` is set and not closed, stays silent when ``_resp`` is ``None``, and stays silent when ``_closed`` is true.
- Adds a ``CHANGES/1033.bugfix.md`` news fragment.

Fixes #1033

## Test plan

- [x] ``uv run --extra test pytest tests/test_stream.py -v --no-cov`` (3 passed)
- [x] ``uv run --extra lint ruff check`` / ``ruff format --check`` on changed files
- [x] ``uv run --extra lint mypy aiodocker/stream.py tests/test_stream.py``
- [x] ``pre-commit run --files`` on changed files