### PR TITLE
fix: do not close caller-supplied session or connector in Docker.close

### DIFF
--- a/CHANGES/1034.bugfix.md
+++ b/CHANGES/1034.bugfix.md
@@ -1,0 +1,1 @@
+Stop closing caller-supplied ``session`` and ``connector`` from :meth:`Docker.close`; only resources created internally are torn down, and :meth:`Docker.close` is now idempotent.

--- a/aiodocker/docker.py
+++ b/aiodocker/docker.py
@@ -134,9 +134,11 @@ class Docker:
             Refer to :doc:`ssh` for more details about SSH transports in the URL.
         connector: Custom :class:`aiohttp.BaseConnector` implementation to establish new connections to the docker host.
             If provided, it will be used instead of creating a connector based on the **url** value.
+            A caller-supplied connector is owned by the caller and is *not* closed by :meth:`close`.
         session: Custom :class:`aiohttp.ClientSession`. If None, a new session will be
             created with the connector and timeout settings.
             The timeout configuration in this object is *ignored* by the **timeout** argument.
+            A caller-supplied session is owned by the caller and is *not* closed by :meth:`close`.
         timeout: :class:`aiohttp.ClientTimeout` configuration for API requests.
             If None, there is no timeout at all.
         ssl_context: SSL context for HTTPS connections. If None and ``DOCKER_TLS_VERIFY``
@@ -165,6 +167,11 @@ class Docker:
         api_version: str = "auto",
         context: str | None = None,
     ) -> None:
+        # Track ownership so close() only tears down what we created here.
+        # Capture the original caller intent before any defaults are filled in.
+        self._owns_connector = connector is None
+        self._owns_session = session is None
+
         docker_host = url  # rename
         context_endpoint: DockerContextEndpoint | None = None
 
@@ -256,6 +263,9 @@ class Docker:
             session = aiohttp.ClientSession(
                 connector=self.connector,
                 timeout=self._timeout,
+                # If the caller owns the connector but not the session, make sure
+                # closing our session does not also close their connector.
+                connector_owner=self._owns_connector,
             )
         self.session = session
 
@@ -292,9 +302,22 @@ class Docker:
 
         Stops the event monitoring and closes the underlying aiohttp session,
         releasing all associated resources including connections.
+
+        Only the session and/or connector that this :class:`Docker` instance
+        created itself are closed; caller-supplied ``session`` or ``connector``
+        objects are left untouched. Calling this method multiple times is safe.
         """
         await self.events.stop()
-        await self.session.close()
+        if self._owns_session:
+            await self.session.close()
+            self._owns_session = False
+            # The wrapping session owns the connector we made, so it has
+            # already been closed by session.close().
+            self._owns_connector = False
+        elif self._owns_connector:
+            # Unusual: caller provided a session but we created the connector.
+            await self.connector.close()
+            self._owns_connector = False
 
     async def auth(self, **credentials: Any) -> dict[str, Any]:
         """Authenticate with Docker registry.

--- a/tests/test_docker_close.py
+++ b/tests/test_docker_close.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import aiohttp
+import pytest
+
+from aiodocker.docker import Docker
+
+
+@pytest.fixture
+def docker_url(monkeypatch: pytest.MonkeyPatch) -> str:
+    """A fake docker host so Docker() can be constructed without a daemon."""
+    monkeypatch.setenv("DOCKER_HOST", "tcp://127.0.0.1:2375")
+    return "tcp://127.0.0.1:2375"
+
+
+async def test_close_default_closes_session(docker_url: str) -> None:
+    """When Docker creates the session itself, close() must close it."""
+    docker = Docker()
+    assert docker._owns_session is True
+    assert docker._owns_connector is True
+
+    await docker.close()
+
+    assert docker.session.closed is True
+
+
+async def test_close_does_not_close_user_session(docker_url: str) -> None:
+    """A caller-supplied session must survive Docker.close()."""
+    connector = aiohttp.TCPConnector()
+    user_session = aiohttp.ClientSession(connector=connector)
+    try:
+        docker = Docker(session=user_session)
+        assert docker._owns_session is False
+        # connector was also caller-supplied transitively via the session,
+        # but Docker only tracks what it directly received.
+        assert docker._owns_connector is True
+
+        await docker.close()
+
+        assert user_session.closed is False
+    finally:
+        await user_session.close()
+
+
+async def test_close_does_not_close_user_connector(docker_url: str) -> None:
+    """A caller-supplied connector must survive Docker.close()."""
+    user_connector = aiohttp.TCPConnector()
+    try:
+        docker = Docker(connector=user_connector)
+        assert docker._owns_session is True
+        assert docker._owns_connector is False
+
+        await docker.close()
+
+        assert docker.session.closed is True
+        assert user_connector.closed is False
+    finally:
+        await user_connector.close()
+
+
+async def test_close_does_not_close_user_session_and_connector(
+    docker_url: str,
+) -> None:
+    """When both session and connector are caller-owned, leave both alone."""
+    user_connector = aiohttp.TCPConnector()
+    user_session = aiohttp.ClientSession(connector=user_connector)
+    try:
+        docker = Docker(connector=user_connector, session=user_session)
+        assert docker._owns_session is False
+        assert docker._owns_connector is False
+
+        await docker.close()
+
+        assert user_session.closed is False
+        assert user_connector.closed is False
+    finally:
+        await user_session.close()
+
+
+async def test_close_is_idempotent_default(docker_url: str) -> None:
+    """Calling close() twice on a default Docker must not raise."""
+    docker = Docker()
+    await docker.close()
+    await docker.close()
+    assert docker.session.closed is True
+
+
+async def test_close_is_idempotent_user_owned(docker_url: str) -> None:
+    """Calling close() twice with caller-supplied session must not raise."""
+    user_session = aiohttp.ClientSession(connector=aiohttp.TCPConnector())
+    try:
+        docker = Docker(session=user_session)
+        await docker.close()
+        await docker.close()
+        assert user_session.closed is False
+    finally:
+        await user_session.close()


### PR DESCRIPTION
## Summary
- `Docker.__init__` accepts user-supplied `session=` / `connector=`, but `Docker.close()` previously always called `await self.session.close()`, destroying instances owned by the caller and (transitively) any connector wrapped in that session.
- Track ownership in `__init__` (before defaults are applied) via `_owns_session` / `_owns_connector`. `close()` now only tears down what `Docker` created itself.
- When the caller provides a connector but we build the wrapping session, the session is created with `connector_owner=False` so closing it does not cascade into the user's connector.
- `close()` is now idempotent: ownership flags are flipped to `False` after teardown.
- Updated docstrings for `session` / `connector` to document the no-close contract.

Fixes #1034

## Test plan
- [x] `uv run pytest tests/test_docker_close.py` — six new tests covering default close, user-owned session, user-owned connector, both user-owned, and double-`close()` idempotency
- [x] `uv run pytest tests/test_context.py tests/test_utils.py tests/test_flow_control_queue.py tests/test_jsonstream.py` — daemon-less suites still green
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run mypy`