### PR TITLE
fix: JSON-encode DockerSwarm.join() request body

### DIFF
--- a/CHANGES/288.bugfix.md
+++ b/CHANGES/288.bugfix.md
@@ -1,0 +1,1 @@
+Fix ``DockerSwarm.join()`` so the request body is JSON-encoded. The endpoint previously sent a form-encoded body with a ``Content-Type: application/json`` header, causing the daemon to reject the request with a JSON decode error.

--- a/aiodocker/swarm.py
+++ b/aiodocker/swarm.py
@@ -99,10 +99,8 @@ class DockerSwarm:
             "DataPathAddr": data_path_addr,
         }
 
-        async with self.docker._query(
-            "swarm/join", method="POST", data=clean_map(data)
-        ):
-            return True
+        await self.docker._query_json("swarm/join", method="POST", data=clean_map(data))
+        return True
 
     async def leave(self, *, force: bool = False) -> bool:
         """

--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -18,8 +18,13 @@ async def test_swarm_failing_joining(swarm):
     system_info = await swarm.system.info()
     swarm_addr = [system_info["Swarm"]["RemoteManagers"][-1]["Addr"]]
     token = swarm_info["JoinTokens"]["Worker"]
-    with pytest.raises(DockerError):
+    with pytest.raises(DockerError) as exc_info:
         await swarm.swarm.join(join_token=token, remote_addrs=swarm_addr)
+    # Daemon must reject because the node is already part of a swarm (503).
+    # If the request body is not JSON-encoded the daemon returns a 400 JSON
+    # decode error instead, which is the regression we want to catch (#288).
+    assert exc_info.value.status == 503
+    assert "already part of a swarm" in exc_info.value.message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `DockerSwarm.join()` called `_query()` with a Python dict and a `Content-Type: application/json` header. Because `_query()` does not JSON-encode the body (only `_query_json()` does, via `json.dumps`), aiohttp form-encoded the dict instead. The daemon rejected the body with `400 invalid JSON: invalid character 'R' looking for beginning of value` (the `R` being from `RemoteAddrs=...`). This is the bug reported in #288.
- Switch the call to `_query_json()` so the body is encoded as JSON, matching the surrounding `init()`/`inspect()` methods.
- Tighten `test_swarm_failing_joining` so it asserts the daemon's real "already part of a swarm" 503 response — the previous version only checked that *any* `DockerError` was raised, so the bug masked itself.

Verified end-to-end against a Docker-in-Docker daemon: pre-fix returned `400 "invalid JSON…"`, post-fix returns `503 "This node is already part of a swarm…"`.

Closes #288.

## Test plan

- [ ] `pytest tests/test_swarm.py::test_swarm_failing_joining` passes with the fix
- [ ] Reverting `aiodocker/swarm.py` to use `_query()` makes the same test fail with status 400, confirming the assertion catches the regression