### PR TITLE
Support item access to DockerVolume

### DIFF
--- a/CHANGES/1044.feature
+++ b/CHANGES/1044.feature
@@ -1,0 +1,1 @@
+Add __getitem__() to DockerVolume

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -17,6 +17,7 @@ Harry Lees
 Hiroki Kiyohara
 Igor Alexandrov
 J. Nick Koston
+James Emerton
 Jason Kraus
 Jonathan Carroll Otsuka
 Joongi Kim

--- a/aiodocker/volumes.py
+++ b/aiodocker/volumes.py
@@ -67,9 +67,9 @@ class DockerVolumes:
 
 
 class DockerVolume:
-    def __init__(self, docker, **kwargs):
+    def __init__(self, docker, name: str = '', **kwargs):
         self.docker = docker
-        self.name = kwargs.get("Name", kwargs.get("name"))
+        self.name = kwargs.get("Name", name)
         self._volume = kwargs
 
     async def show(self):

--- a/aiodocker/volumes.py
+++ b/aiodocker/volumes.py
@@ -67,7 +67,7 @@ class DockerVolumes:
 
 
 class DockerVolume:
-    def __init__(self, docker, name: str = '', **kwargs):
+    def __init__(self, docker, name: str = "", **kwargs):
         self.docker = docker
         self.name = kwargs.get("Name", name)
         self._volume = kwargs

--- a/aiodocker/volumes.py
+++ b/aiodocker/volumes.py
@@ -29,16 +29,16 @@ class DockerVolumes:
         data = await self.docker._query_json("volumes", params=params)
         return data
 
-    async def get(self, id):
+    async def get(self, id) -> 'DockerVolume':
         data = await self.docker._query_json(f"volumes/{id}", method="GET")
-        return DockerVolume(self.docker, data["Name"])
+        return DockerVolume(self.docker, **data)
 
-    async def create(self, config):
+    async def create(self, config) -> 'DockerVolume':
         config = json.dumps(config, sort_keys=True).encode("utf-8")
         data = await self.docker._query_json(
             "volumes/create", method="POST", data=config
         )
-        return DockerVolume(self.docker, data["Name"])
+        return DockerVolume(self.docker, **data)
 
     async def prune(
         self,
@@ -67,12 +67,14 @@ class DockerVolumes:
 
 
 class DockerVolume:
-    def __init__(self, docker, name):
+    def __init__(self, docker, **kwargs):
         self.docker = docker
-        self.name = name
+        self.name = kwargs.get('Name', kwargs.get('name'))
+        self._volume = kwargs
 
     async def show(self):
         data = await self.docker._query_json(f"volumes/{self.name}")
+        self._volume = data
         return data
 
     async def delete(self, force=False):
@@ -80,3 +82,9 @@ class DockerVolume:
             f"volumes/{self.name}", method="DELETE", params=dict(force=force)
         ):
             pass
+
+    def __getitem__(self, key: str) -> Any:
+        return self._volume[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._volume

--- a/aiodocker/volumes.py
+++ b/aiodocker/volumes.py
@@ -29,11 +29,11 @@ class DockerVolumes:
         data = await self.docker._query_json("volumes", params=params)
         return data
 
-    async def get(self, id) -> 'DockerVolume':
+    async def get(self, id) -> "DockerVolume":
         data = await self.docker._query_json(f"volumes/{id}", method="GET")
         return DockerVolume(self.docker, **data)
 
-    async def create(self, config) -> 'DockerVolume':
+    async def create(self, config) -> "DockerVolume":
         config = json.dumps(config, sort_keys=True).encode("utf-8")
         data = await self.docker._query_json(
             "volumes/create", method="POST", data=config
@@ -69,7 +69,7 @@ class DockerVolumes:
 class DockerVolume:
     def __init__(self, docker, **kwargs):
         self.docker = docker
-        self.name = kwargs.get('Name', kwargs.get('name'))
+        self.name = kwargs.get("Name", kwargs.get("name"))
         self._volume = kwargs
 
     async def show(self):

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -15,7 +15,7 @@ async def test_create_search_get_delete(docker: Docker) -> None:
         "Labels": {"some": "label"},
         "Driver": "local",
     })
-    assert create_response['Name'] == name
+    assert create_response["Name"] == name
     volumes_response = await docker.volumes.list(filters={"label": "some=label"})
     volumes = volumes_response["Volumes"]
     assert len(volumes) == 1

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -10,11 +10,12 @@ from aiodocker.volumes import DockerVolume
 @pytest.mark.asyncio
 async def test_create_search_get_delete(docker: Docker) -> None:
     name = "aiodocker-test-volume-two"
-    await docker.volumes.create({
+    create_response = await docker.volumes.create({
         "Name": name,
         "Labels": {"some": "label"},
         "Driver": "local",
     })
+    assert create_response['Name'] == name
     volumes_response = await docker.volumes.list(filters={"label": "some=label"})
     volumes = volumes_response["Volumes"]
     assert len(volumes) == 1


### PR DESCRIPTION
Implement kwargs and `__getitem__()` as per `DockerContainer`

## What do these changes do?

This allows the user to access properties of a volume directly from the `DockerVolume` instance.

## Are there changes in behavior for the user?

Arguments to `DockerVolume` constructor have changed. I have added support for a positional `name` argument.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
