### PR TITLE
feat: stream container archives

### DIFF
--- a/CHANGES/547.feature.rst
+++ b/CHANGES/547.feature.rst
@@ -1,0 +1,1 @@
+Add ``DockerContainer.get_archive_stream()`` to stream a container archive in bounded chunks, keeping peak memory flat instead of buffering the whole archive as ``get_archive()`` does.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -7,6 +7,7 @@ Byeongjun Park
 Cecil Tonglet
 Christian Barra
 Danny Song
+Dex Hunter
 Darwin Monroy
 Edgar Ramírez Mondragón
 eevelweezel

--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -263,6 +263,41 @@ class DockerContainer:
             assert isinstance(data, tarfile.TarFile)
             return data
 
+    async def get_archive_stream(
+        self, path: str, *, chunk_size: int = 64 * 1024
+    ) -> AsyncIterator[bytes]:
+        """Stream the tar archive at *path* in bounded chunks.
+
+        Unlike :meth:`get_archive`, which reads the whole archive into memory,
+        this yields the archive in ``chunk_size``-byte pieces so peak memory
+        stays flat regardless of archive size.
+
+        This is an async generator: iterate it, do not await it::
+
+            async for chunk in container.get_archive_stream("/etc"):
+                ...
+
+        ``chunk_size`` must be a positive integer (validated on first
+        iteration). Callers that may stop early should wrap the iterator in
+        :func:`contextlib.aclosing` for deterministic connection release.
+        """
+        if (
+            not isinstance(chunk_size, int)
+            or isinstance(chunk_size, bool)
+            or chunk_size <= 0
+        ):
+            raise ValueError("chunk_size must be a positive integer")
+        async with self.docker._query(
+            f"containers/{self._id}/archive",
+            method="GET",
+            params={"path": path},
+        ) as response:
+            try:
+                async for chunk in response.content.iter_chunked(chunk_size):
+                    yield chunk
+            finally:
+                response.close()
+
     async def put_archive(self, path, data):
         async with self.docker._query(
             f"containers/{self._id}/archive",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -472,7 +472,6 @@ async def test_get_archive_stream(
             pass
 
 
-
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Port is not exposed on Windows by some reason"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -444,7 +444,8 @@ async def test_get_archive_stream(
 
     # Streamed bytes reassemble to the same tar as get_archive().
     chunks = [
-        chunk async for chunk in container.get_archive_stream("tmp/foo.txt", chunk_size=4)
+        chunk
+        async for chunk in container.get_archive_stream("tmp/foo.txt", chunk_size=4)
     ]
     assert len(chunks) > 1  # small chunk_size actually splits the body
     data = b"".join(chunks)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,7 @@ import ssl
 import sys
 import tarfile
 import time
-from typing import Any, List
+from typing import Any, List, cast
 
 import aiohttp
 import pytest
@@ -413,6 +413,64 @@ async def test_get_archive(
     foo_file = tar_archive.extractfile("foo.txt")
     assert foo_file is not None
     assert foo_file.read() == b"test\n"
+
+
+@pytest.mark.asyncio
+async def test_get_archive_stream(
+    image_name: str,
+    make_container: AsyncContainerFactory,
+) -> None:
+    skip_windows()
+
+    config: dict[str, Any] = {
+        "Cmd": [
+            "python",
+            "-c",
+            "with open('tmp/foo.txt', 'w') as f: f.write('test\n')",
+        ],
+        "Image": image_name,
+        "AttachStdin": False,
+        "AttachStdout": False,
+        "AttachStderr": False,
+        "Tty": True,
+        "OpenStdin": False,
+    }
+
+    container = await make_container(
+        config, name="aiodocker-testing-get-archive-stream"
+    )
+    await container.start()
+    await asyncio.sleep(1)
+
+    # Streamed bytes reassemble to the same tar as get_archive().
+    chunks = [
+        chunk async for chunk in container.get_archive_stream("tmp/foo.txt", chunk_size=4)
+    ]
+    assert len(chunks) > 1  # small chunk_size actually splits the body
+    data = b"".join(chunks)
+    tar_archive = tarfile.open(fileobj=io.BytesIO(data))
+    assert len(tar_archive.getmembers()) == 1
+    foo_file = tar_archive.extractfile("foo.txt")
+    assert foo_file is not None
+    assert foo_file.read() == b"test\n"
+
+    # Early abandonment: breaking out of the stream must not error.
+    async for _chunk in container.get_archive_stream("tmp/foo.txt"):
+        break
+
+    # chunk_size guard is enforced on iteration.
+    for bad in (0, -1, True):
+        with pytest.raises(ValueError):
+            async for _ in container.get_archive_stream("tmp/foo.txt", chunk_size=bad):
+                pass
+
+    with pytest.raises(ValueError):
+        async for _ in container.get_archive_stream(
+            "tmp/foo.txt", chunk_size=cast(int, "x")
+        ):
+            pass
+
+    await container.delete(force=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -471,7 +471,6 @@ async def test_get_archive_stream(
         ):
             pass
 
-    await container.delete(force=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -426,7 +426,7 @@ async def test_get_archive_stream(
         "Cmd": [
             "python",
             "-c",
-            "with open('tmp/foo.txt', 'w') as f: f.write('test\n')",
+            "with open('tmp/foo.txt', 'w') as f: f.write('test\\n')",
         ],
         "Image": image_name,
         "AttachStdin": False,


### PR DESCRIPTION
## What do these changes do?

Add `DockerContainer.get_archive_stream()`, an async iterator that reads the Docker archive response in bounded chunks instead of buffering the entire tar archive in memory.

## Are there changes in behavior for the user?

Consumers can stream large container archives with `async for`, avoiding the whole-archive memory cost of `get_archive()`. The new method validates `chunk_size` and closes the response when iteration completes or is explicitly closed.

## Related issue number

Fixes #547

## Validation

- `uvx ruff check --fix .`
- `uv run mypy aiodocker/containers.py tests/test_integration.py`
- Isolated async streaming smoke test covering byte order, invalid chunk sizes, and early-close cleanup
- Added the Docker integration test alongside `test_get_archive`

The Docker integration test could not run on the validation host because the `docker` executable is unavailable there; it is included for upstream CI.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Added myself to `CONTRIBUTORS.txt`
- [x] Added `CHANGES/547.feature.rst`