### PR TITLE
Add one_shot parameter to DockerContainer.stats()

### DIFF
--- a/CHANGES/1054.feature
+++ b/CHANGES/1054.feature
@@ -1,0 +1,1 @@
+Added the ``one_shot`` parameter to ``DockerContainer.stats()``, allowing a single immediate stats sample (Docker API 1.41+) instead of waiting ~1 s for the daemon's two-sample collection.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -32,6 +32,7 @@ Paul Tagliamonte
 Robin Tweedie
 Sanghun Lee
 Saulius Adamonis
+Stefan Agner
 Tianon Gravi
 Tommy Beadle
 Travis DePrato

--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -524,6 +524,7 @@ class DockerContainer:
         self,
         *,
         stream: Literal[False],
+        one_shot: bool = False,
         timeout: float | ClientTimeout | Sentinel | None = SENTINEL,
     ) -> list[dict[str, Any]]: ...
 
@@ -531,14 +532,22 @@ class DockerContainer:
         self,
         *,
         stream: bool = True,
+        one_shot: bool = False,
         timeout: float | ClientTimeout | Sentinel | None = SENTINEL,
     ) -> Any:
+        if stream and one_shot:
+            raise ValueError("one_shot is only applicable with stream=False")
+
         # Default to infinite timeout for stats operations
         timeout_config = self.docker._resolve_long_running_timeout(timeout)
 
+        params = {"stream": "1" if stream else "0"}
+        if one_shot:
+            params["one-shot"] = "1"
+
         cm = self.docker._query(
             f"containers/{self._id}/stats",
-            params={"stream": "1" if stream else "0"},
+            params=params,
             timeout=timeout_config,
         )
         if stream:

--- a/aiodocker/containers.py
+++ b/aiodocker/containers.py
@@ -516,6 +516,7 @@ class DockerContainer:
         self,
         *,
         stream: Literal[True] = True,
+        one_shot: Literal[False] = False,
         timeout: float | ClientTimeout | Sentinel | None = SENTINEL,
     ) -> AsyncIterator[dict[str, Any]]: ...
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -179,7 +179,8 @@ async def test_container_stats_one_shot_with_stream_raises(
 
     try:
         with pytest.raises(ValueError):
-            container.stats(stream=True, one_shot=True)
+            # combination rejected at runtime and excluded from the overloads
+            container.stats(stream=True, one_shot=True)  # type: ignore[call-overload]
     finally:
         await container.delete(force=True)
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -144,6 +144,47 @@ async def test_container_stats_list(docker: Docker, image_name: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_container_stats_one_shot(docker: Docker, image_name: str) -> None:
+    container = await docker.containers.run(
+        config={
+            "Cmd": ["-c", "print('hello')"],
+            "Entrypoint": ["python"],
+            "Image": image_name,
+        }
+    )
+
+    try:
+        await container.start()
+        response = await container.wait()
+        assert response["StatusCode"] == 0
+        stats = await container.stats(stream=False, one_shot=True)
+        assert "cpu_stats" in stats[0]
+        # one-shot mode returns a single sample without a precpu baseline
+        assert "system_cpu_usage" not in stats[0]["precpu_stats"]
+    finally:
+        await container.delete(force=True)
+
+
+@pytest.mark.asyncio
+async def test_container_stats_one_shot_with_stream_raises(
+    docker: Docker, image_name: str
+) -> None:
+    container = await docker.containers.run(
+        config={
+            "Cmd": ["-c", "print('hello')"],
+            "Entrypoint": ["python"],
+            "Image": image_name,
+        }
+    )
+
+    try:
+        with pytest.raises(ValueError):
+            container.stats(stream=True, one_shot=True)
+    finally:
+        await container.delete(force=True)
+
+
+@pytest.mark.asyncio
 async def test_container_stats_stream(docker: Docker, image_name: str) -> None:
     container = await docker.containers.run(
         config={


### PR DESCRIPTION
## What do these changes do?

Add a `one_shot` keyword argument to `DockerContainer.stats()`, mapping to the Docker Engine API's `one-shot` query parameter (API 1.41+). Combined with `stream=False`, the daemon reads the container stats once and returns immediately instead of registering the request with its internal 1 s stats collector and waiting for two ticks — a stats call returns in tens of milliseconds rather than ~1 s, which matters when sampling many containers periodically. In one-shot mode `precpu_stats` is not populated, per the API contract.

Combining `one_shot=True` with `stream=True` raises `ValueError`, as the one-shot sampling behavior only applies to non-streaming requests.

## Are there changes in behavior for the user?

No. The new keyword is opt-in and defaults to `False`; existing calls are unchanged.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
